### PR TITLE
Feat(scanner): multi-line support and block comments

### DIFF
--- a/examples/multi-line.lox
+++ b/examples/multi-line.lox
@@ -1,19 +1,21 @@
-// run in --scanning mode
+// run in --scanning mode with --ml flag
 // los comentarios no se toman como tokens
 1 + 2 // expresión simple
-1 + // expresión invalida
 ( ) { } , . // un par de tokens
 ! se interpreta distinto a !=
 "string literal"
-"string sin terminar
 321 1.5 // numeros literales
 var true false nil // palabras reservadas
 trueman xxx yyy // identificadores
-` // caracter invalido
 1 + 2 /* comentario multilinea */
 /* comentario al inicio */ var x = 10
-1 + /* este comentario no se cierra
 1 /* **** ****** * */ 2
 1/*c*/+/*d*/2
-1 /* nested /* asd */ comments */ 2
-/* nested /* sin */ cerrar 
+
+
+var = /* comentario 
+/* 
+multi */ 
+linea 
+*/ 
+2

--- a/examples/multi-line.lox
+++ b/examples/multi-line.lox
@@ -1,4 +1,4 @@
-// run in --scanning mode with --ml flag
+// run in --scanning mode
 // los comentarios no se toman como tokens
 1 + 2 // expresión simple
 ( ) { } , . // un par de tokens

--- a/examples/parsing.lox
+++ b/examples/parsing.lox
@@ -1,4 +1,4 @@
-// run in --parsing mode
+// run in --parsing and --line-by-line modes!!
 // expresiones literales
 true;
 false;

--- a/examples/scanning.lox
+++ b/examples/scanning.lox
@@ -16,3 +16,5 @@ var /* comentario \n en \n varias \n lineas */ 123
 1 + /* este comentario no se cierra
 1 /* **** ****** * */ 2
 1/*c*/+/*d*/2
+1 /* nested /* asd */ comments */ 2
+/* nested /* sin */ cerrar 

--- a/examples/scanning.lox
+++ b/examples/scanning.lox
@@ -1,4 +1,4 @@
-// run in --scanning mode
+// run in --scanning and --line-by-line modes!!
 // los comentarios no se toman como tokens
 1 + 2 // expresión simple
 1 + // expresión invalida

--- a/examples/scanning.lox
+++ b/examples/scanning.lox
@@ -10,3 +10,9 @@
 var true false nil // palabras reservadas
 trueman xxx yyy // identificadores
 ` // caracter invalido
+1 + 2 /* comentario multilinea */
+/* comentario al inicio */ var x = 10
+var /* comentario \n en \n varias \n lineas */ 123
+1 + /* este comentario no se cierra
+1 /* **** ****** * */ 2
+1/*c*/+/*d*/2

--- a/plox.py
+++ b/plox.py
@@ -31,11 +31,11 @@ class Plox:
     def __init__(self):
         self.debug = False
         self.mode = None  # "scanning" | "parsing" | "resolve"
+        self.multi_line = False
         self.interpreter = Interpreter()
 
     def run(self, source: str):
         scanner = Scanner(source)
-
         try:
             tokens = scanner.scan()
         except Exception as e:
@@ -114,6 +114,9 @@ class Plox:
             "--resolve", action="store_true", help="Run in resolve mode"
         )
         parser.add_argument(
+            "--ml", action="store_true", help="Run in multi-line mode"
+        )
+        parser.add_argument(
             "file", nargs="?", help="Interpret a file instead of running the REPL"
         )
 
@@ -129,14 +132,22 @@ class Plox:
         elif args.resolve:
             self.mode = "resolve"
 
+        if args.ml:
+            self.multi_line = True
+
         if args.file:
             with open(args.file, "r") as file:
+                if self.multi_line:
+                    source = file.read()
+                    print(source)
+                    self.run(source)
                 # Acá estamos haciendo uso de que Python ya sabe dividir archivos en lineas,
                 # pero lo correcto sería manejar correctamente los \n en el scanner de lox
-                for line in file:
-                    if self.mode:
-                        print(f"> {line.strip()}")
-                    self.run(line.strip())
+                else:
+                    for line in file:
+                        if self.mode:
+                            print(f"> {line.strip()}")
+                        self.run(line)
             return
 
         while True:

--- a/plox.py
+++ b/plox.py
@@ -31,7 +31,6 @@ class Plox:
     def __init__(self):
         self.debug = False
         self.mode = None  # "scanning" | "parsing" | "resolve"
-        self.multi_line = False
         self.interpreter = Interpreter()
 
     def run(self, source: str):
@@ -47,7 +46,7 @@ class Plox:
         # en modo scanning, solo imprimimos los tokens
         if self.mode == "scanning":
             for i, token in enumerate(tokens):
-                print(colored(f"token {i}: {token}", "light_blue"))
+                print(colored(f"line {token.line} | {token}", "light_blue"))
             return
 
         parser = Parser(tokens)
@@ -114,7 +113,7 @@ class Plox:
             "--resolve", action="store_true", help="Run in resolve mode"
         )
         parser.add_argument(
-            "--ml", action="store_true", help="Run in multi-line mode"
+            "--line-by-line", action="store_true", help="Run in line-by-line mode"
         )
         parser.add_argument(
             "file", nargs="?", help="Interpret a file instead of running the REPL"
@@ -132,22 +131,20 @@ class Plox:
         elif args.resolve:
             self.mode = "resolve"
 
-        if args.ml:
-            self.multi_line = True
-
         if args.file:
             with open(args.file, "r") as file:
-                if self.multi_line:
-                    source = file.read()
-                    print(source)
-                    self.run(source)
-                # Acá estamos haciendo uso de que Python ya sabe dividir archivos en lineas,
-                # pero lo correcto sería manejar correctamente los \n en el scanner de lox
-                else:
+                # Modo line by line, sin tener en cuenta los saltos de linea
+                # Acá estamos haciendo uso de que Python ya sabe dividir archivos en lineas
+                if args.line_by_line:
                     for line in file:
                         if self.mode:
                             print(f"> {line.strip()}")
                         self.run(line)
+                # modo multi-linea por default
+                else:
+                    source = file.read()
+                    self.run(source)
+                    
             return
 
         while True:

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -79,11 +79,13 @@ class Scanner(object):
                     # consumimos el resto de la linea
                     while not self._is_at_end():
                         self._advance()
+                # si es un comentario multilinea, lo ignoramos
                 elif self._match("*"):
                     while not self._is_at_end():
                         if self._match("*") and self._match("/"):
                             return
                         self._advance()
+                    # si llegamos al final de la linea, sin cerrar el comentario, es un error
                     raise Exception(f"Unterminated comment: `{self.lexeme()}`")
                 else:
                     self.add_token(TokenType.SLASH)

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -77,7 +77,7 @@ class Scanner(object):
                 # si es un comentario, lo ignoramos
                 if self._match("/"):
                     # consumimos el resto de la linea
-                    while not self._is_at_end():
+                    while not self._match("\n") and not self._is_at_end():
                         self._advance()
                 # si es un comentario multilinea, lo ignoramos
                 elif self._match("*"):

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -83,20 +83,21 @@ class Scanner(object):
                     while not self._lookahead() == "\n" and not self._is_at_end():
                         self._advance()
                 # si es un comentario multilinea, lo ignoramos
+                # se permiten comentarios anidados de n niveles del estilo /* /* ... */ */
                 elif self._match("*"):
                     level = 1
                     while level > 0 and not self._is_at_end():
                         if self._match("\n"):
                             self._line += 1
                             continue
-                        if self._match("*") and self._match("/"):
+                        if self._match("*") and self._match("/"):  # cierre de comentario
                             level -= 1
                             continue
-                        if self._match("/") and self._match("*"):
+                        if self._match("/") and self._match("*"):  # apertura de comentario
                             level += 1
                             continue
                         self._advance()
-                    # si llegamos al final de la linea, sin cerrar el comentario, es un error
+                    # si llegamos al final del archivo, sin cerrar el comentario, es un error
                     if level > 0:
                         raise Exception(f"Unterminated comment: `{self.lexeme()}`")
                 else:

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -79,6 +79,12 @@ class Scanner(object):
                     # consumimos el resto de la linea
                     while not self._is_at_end():
                         self._advance()
+                elif self._match("*"):
+                    while not self._is_at_end():
+                        if self._match("*") and self._match("/"):
+                            return
+                        self._advance()
+                    raise Exception(f"Unterminated comment: `{self.lexeme()}`")
                 else:
                     self.add_token(TokenType.SLASH)
 

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -81,12 +81,18 @@ class Scanner(object):
                         self._advance()
                 # si es un comentario multilinea, lo ignoramos
                 elif self._match("*"):
-                    while not self._is_at_end():
+                    level = 1
+                    while level > 0 and not self._is_at_end():
                         if self._match("*") and self._match("/"):
-                            return
+                            level -= 1
+                            continue
+                        if self._match("/") and self._match("*"):
+                            level += 1
+                            continue
                         self._advance()
                     # si llegamos al final de la linea, sin cerrar el comentario, es un error
-                    raise Exception(f"Unterminated comment: `{self.lexeme()}`")
+                    if level > 0:
+                        raise Exception(f"Unterminated comment: `{self.lexeme()}`")
                 else:
                     self.add_token(TokenType.SLASH)
 

--- a/plox/Token.py
+++ b/plox/Token.py
@@ -62,11 +62,12 @@ TokenLiteralType = Union[float, str, bool, None]
 
 class Token(object):
     def __init__(
-        self, token_type: TokenType, *, lexeme: str, literal: TokenLiteralType
+        self, token_type: TokenType, *, lexeme: str, literal: TokenLiteralType, line: int
     ):
         self.token_type = token_type  # Que tipo de token es
         self.lexeme = lexeme  # Los caracteres en sí, crudos
         self.literal = literal  # Si es un literal, aprovechamos y nos almacenamos directamente el valor al que resuelve
+        self.line = line # Numero de linea donde se encuentra el caracter para devolver errores mas especificos
 
     def __repr__(self) -> str:
         return f"{self.token_type.name} '{self.lexeme}'"


### PR DESCRIPTION
# Soporte para multilínea y comentarios de bloque

## Resumen
Se implementa soporte para escaneo teniendo en cuenta saltos de línea (`\n`), se agregan comentarios de bloque (`/* ... */`) y se mejoran los comentarios de línea (`//`). También se añade seguimiento de línea en `Token` y `Scanner` para errores con mayor precisión.

## Cambios realizados
-  Ahora el modo default de lectura de archivos es multilínea.
- Nueva flag `--line-by-line`: Esta nueva flag permite leer el archivo linea por linea, descartando saltos de línea. Es una flag para mantener el comportamiento anterior y poder seguir probando ejemplos con varios errores como en `/examples/scanning.lox`
- Se agrega contador de línea en `Scanner` y se incluye el número de línea en `Token`. Esto facilita mensajes de error más específicos (en el futuro se puede agregar columna).  
- Corrección en el manejo de comentarios `//`: ahora cortan en el primer `\n` o en EOF, en lugar de consumir hasta EOF.  
- Implementación de comentarios de bloque `/* ... */`, con:
  - Soporte para comentarios multilínea.
  - Soporte para comentarios anidados (`/* /* ... */ */`).  
- Casos de prueba añadidos: casos de comentarios en línea, bloque, multilínea, sin cierre (error), y comentarios adyacentes a tokens.

## Comportamiento
- Por default se corre en modo multilínea
- Compatible con el formato anterior usando la flag `--line-by-line`.  
- Errores por comentarios no cerrados lanzan una excepción.

## Ejemplos
1. Comentario de bloque multilínea:

```
$ python3 plox.py --scanning ejemplo.lox

/* comentario
   multi
   linea*/
123

# Tokens: NUMBER(123), EOF
```

2. Comentario de bloque anidado:

```
$ python3 plox.py --scanning ejemplo.lox

1 /* comentario /* bloque*/ anidado */ + 2

# Tokens: NUMBER(1), PLUS(+), NUMBER(2), EOF
```

3. Comentario sin cerrar:

```
$ python3 plox.py --scanning ejemplo.lox

1 + /* comentario sin cerrar

# Resultado: Scanning Error: Unterminated comment: `/*  comentario sin cerrar`
```

