### PR TITLE
feat(scanner): support single-quoted strings

### DIFF
--- a/examples/multi-line.lox
+++ b/examples/multi-line.lox
@@ -19,3 +19,6 @@ multi */
 linea 
 */ 
 2
+
+"string
+multilinea"

--- a/examples/scanning.lox
+++ b/examples/scanning.lox
@@ -6,6 +6,8 @@
 ! se interpreta distinto a !=
 "string literal"
 "string sin terminar
+'string con comillas simples'
+'string sin terminar
 321 1.5 // numeros literales
 var true false nil // palabras reservadas
 trueman xxx yyy // identificadores

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -121,15 +121,29 @@ class Scanner(object):
                     TokenType.GREATER_EQUAL if self._match("=") else TokenType.GREATER
                 )
 
-            # literales
-            case '"' | '\'':
-                delimiter = c
-                # consumimos la cadena hasta el delimitador de cierre
-                while not self._is_at_end() and not self._lookahead() == delimiter:
+            case '\'':
+                # consumimos la cadena hasta el proximo ' o hasta el fin de linea
+                while not self._is_at_end() and not self._lookahead() == '\'' and not self._lookahead() == "\n":
+                    self._advance()
+
+                if self._is_at_end() or self._lookahead() == "\n":
+                    # si llegamos al final de la linea, sin cerrar la cadena, es un error
+                    raise Exception(f"Unterminated string: `{self.lexeme()}`")
+
+                self._advance()  # consumimos el cierre de la cadena
+
+                # la cadena la guardamos sin las comillas
+                str_value = self._source[self._start + 1 : self._current - 1]
+                self.add_token(TokenType.STRING, literal=str_value)
+
+            # string multilinea
+            case '"':
+                # consumimos la cadena hasta el proximo "
+                while not self._is_at_end() and not self._lookahead() == '"':
                     self._advance()
 
                 if self._is_at_end():
-                    # si llegamos al final de la linea, sin cerrar la cadena, es un error
+                    # si llegamos al final del archivo, sin cerrar la cadena, es un error
                     raise Exception(f"Unterminated string: `{self.lexeme()}`")
 
                 self._advance()  # consumimos el cierre de la cadena

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -124,7 +124,7 @@ class Scanner(object):
             # literales
             case '"' | '\'':
                 delimiter = c
-                # consumimos la cadena hasta el proximo delimitador
+                # consumimos la cadena hasta el delimitador de cierre
                 while not self._is_at_end() and not self._lookahead() == delimiter:
                     self._advance()
 

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -122,9 +122,10 @@ class Scanner(object):
                 )
 
             # literales
-            case '"':
-                # consumimos la cadena hasta el proximo "
-                while not self._is_at_end() and not self._lookahead() == '"':
+            case '"' | '\'':
+                delimiter = c
+                # consumimos la cadena hasta el proximo delimitador
+                while not self._is_at_end() and not self._lookahead() == delimiter:
                     self._advance()
 
                 if self._is_at_end():

--- a/plox/Token.py
+++ b/plox/Token.py
@@ -70,7 +70,11 @@ class Token(object):
         self.line = line # Numero de linea donde se encuentra el caracter para devolver errores mas especificos
 
     def __repr__(self) -> str:
-        return f"{self.line} | {self.token_type.name} '{self.lexeme}'"
+        lexeme = self.lexeme
+        if self.token_type == TokenType.STRING:
+            # Replace newline with "\n"
+            lexeme = self.lexeme.replace("\n", "\\n")
+        return f"{self.line} | {self.token_type.name} '{lexeme}'"
 
 
 TokenKeywords = {


### PR DESCRIPTION
Introduce los siguientes cambios al scanner:
* Los lexemas delimitados por comillas simples (`'`) ahora también son considerados como strings (single-line).
   Para implementar esto, se replica la lógica de escaneo existente para strings con comillas dobles, pero chequeando que la comilla de cierre esté en la misma línea, es decir, que la string sea single-line.
* Se modifica la representación de las cadenas literales para que imprima `\n` en lugar de imprimir el salto de linea.

Además, se agregan ejemplos de strings single-line y multiline.