### PR TITLE
feat (parser): postfix increment operator

### DIFF
--- a/examples/parsing.lox
+++ b/examples/parsing.lox
@@ -18,6 +18,10 @@ nil;
 // agrupamientos
 (true);
 (1 + 5);
+// expresiones postfix
+x++;
+func()++;
+-x++;
 // expresiones invalidas
 1 +;
 ( 2 + 2;

--- a/examples/scanning.lox
+++ b/examples/scanning.lox
@@ -9,6 +9,8 @@
 "string sin terminar
 'string sin terminar
 321 1.5 // números literales
+++ // operador de incremento
+x++ // identificador y operador de incremento
 1..2 // número inválido con múltiples puntos consecutivos
 1.5.2 // número inválidos con múltiples puntos
 1. // número inválido terminando en punto

--- a/plox/Expr.py
+++ b/plox/Expr.py
@@ -87,3 +87,13 @@ class LogicExpr(Expr):
 
     def __repr__(self) -> str:
         return f"Logic: [{self._left}  {self._operator.lexeme} {self._right}]"
+
+
+# postfix         → expression "++" ;
+class PostfixExpr(Expr):
+    def __init__(self, operator: Token, left: Expr):
+        self._left = left
+        self._operator = operator
+
+    def __repr__(self) -> str:
+        return f"Postfix: [{self._left} {self._operator.lexeme}]"

--- a/plox/Expr.py
+++ b/plox/Expr.py
@@ -91,7 +91,7 @@ class LogicExpr(Expr):
 
 # postfix         → expression "++" ;
 class PostfixExpr(Expr):
-    def __init__(self, operator: Token, left: Expr):
+    def __init__(self, left: Expr, operator: Token):
         self._left = left
         self._operator = operator
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -448,7 +448,7 @@ class Parser(object):
         # ejemplo: x++, func()++
         while not self._is_at_end() and self._match(TokenType.PLUS_PLUS):
             operator = self._previous()
-            expr = PostfixExpr(operator, expr)
+            expr = PostfixExpr(expr, operator)
 
         return expr
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -9,6 +9,7 @@ from .Expr import (
     AssignmentExpr,
     LogicExpr,
     CallExpr,
+    PostfixExpr,
 )
 from .Stmt import (
     Stmt,
@@ -424,7 +425,7 @@ class Parser(object):
 
         return expr
 
-    # unary          → ( "!" | "-" ) unary | call ;
+    # unary          → ( "!" | "-" ) unary | postfix ;
     def unary(self) -> Expr:
         # a diferencia de las reglas de expresiones binarias,
         # acá el operador es un prefijo.
@@ -434,8 +435,22 @@ class Parser(object):
             right = self.unary()
             return UnaryExpr(operator, right)
 
-        # Si no tuve recursividad de unarios, entonces tengo una llamada a una función
-        return self.call()
+        # Si no tuve recursividad de unarios, entonces tengo una llamada a un prefijo
+        return self.postfix()
+    
+    # postfix        → call ( "++" )* ;
+    def postfix(self) -> Expr:
+        # acá el operador es un sufijo
+        # primero chequeamos lo que tenemos a la izquierda, y después seguimos
+        expr = self.call()
+
+        # mientras nos crucemos ++, seguimos parseando
+        # ejemplo: x++, func()++
+        while not self._is_at_end() and self._match(TokenType.PLUS_PLUS):
+            operator = self._previous()
+            expr = PostfixExpr(operator, expr)
+
+        return expr
 
     # call           → primary ( "(" arguments? ")" )* ;
     # arguments      → expression ( "," expression )* ;

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -70,7 +70,13 @@ class Scanner(object):
             case "-":
                 self.add_token(TokenType.MINUS)
             case "+":
-                self.add_token(TokenType.PLUS)
+                # caso especial para el +
+                # si es ++, es un token PLUS_PLUS
+                if self._match("+"):
+                    self.add_token(TokenType.PLUS_PLUS)
+                # si no, es un token PLUS
+                else:
+                    self.add_token(TokenType.PLUS)
             case ";":
                 self.add_token(TokenType.SEMICOLON)
             case "*":

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -69,14 +69,6 @@ class Scanner(object):
                 self.add_token(TokenType.DOT)
             case "-":
                 self.add_token(TokenType.MINUS)
-            case "+":
-                # caso especial para el +
-                # si es ++, es un token PLUS_PLUS
-                if self._match("+"):
-                    self.add_token(TokenType.PLUS_PLUS)
-                # si no, es un token PLUS
-                else:
-                    self.add_token(TokenType.PLUS)
             case ";":
                 self.add_token(TokenType.SEMICOLON)
             case "*":
@@ -110,6 +102,10 @@ class Scanner(object):
                     self.add_token(TokenType.SLASH)
 
             # tokens de uno o dos caracteres
+            case "+":
+                self.add_token(
+                    TokenType.PLUS_PLUS if self._match("+") else TokenType.PLUS
+                )
             case "!":
                 self.add_token(
                     TokenType.BANG_EQUAL if self._match("=") else TokenType.BANG

--- a/plox/Token.py
+++ b/plox/Token.py
@@ -12,6 +12,7 @@ class TokenType(Enum):
     DOT = auto()
     MINUS = auto()
     PLUS = auto()
+    PLUS_PLUS = auto()
     SEMICOLON = auto()
     STAR = auto()
 

--- a/plox/Token.py
+++ b/plox/Token.py
@@ -11,8 +11,6 @@ class TokenType(Enum):
     COMMA = auto()
     DOT = auto()
     MINUS = auto()
-    PLUS = auto()
-    PLUS_PLUS = auto()
     SEMICOLON = auto()
     STAR = auto()
 
@@ -22,6 +20,8 @@ class TokenType(Enum):
     SLASH = auto()
 
     # tokens de uno o dos caracteres
+    PLUS = auto()
+    PLUS_PLUS = auto()
     BANG = auto()
     BANG_EQUAL = auto()
     EQUAL = auto()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,19 @@
+import pytest
+from plox.Scanner import Scanner
+from plox.Token import TokenType
+
+def test_scanner_plus_plus_token():
+    tokens = Scanner("++").scan()
+    tokens_type = [token.token_type for token in tokens]
+
+    expected_tokens_type = [TokenType.PLUS_PLUS, TokenType.EOF]
+
+    assert tokens_type == expected_tokens_type
+
+def test_plus_plus_token_and_plus_token():
+    tokens = Scanner("+++").scan()
+    tokens_type = [token.token_type for token in tokens]
+    
+    expected_tokens_type = [TokenType.PLUS_PLUS, TokenType.PLUS, TokenType.EOF]
+   
+    assert tokens_type == expected_tokens_type


### PR DESCRIPTION
# Agregado del operador x++

## Resumen

Se agrega escaneo y parseo del operador `++` a Plox.

## Cambios realizados

1.[ `Token.py`](https://github.com/AlanValdevenito/plox/blob/feature/postfix-increment-operator/plox/Token.py): Se agrega el token `PLUS_PLUS` para representar al operador `++`
2. [`Scanner.py`](https://github.com/AlanValdevenito/plox/blob/feature/postfix-increment-operator/plox/Scanner.py): Se modifica el case del operador `+` para que permita el escaneo del operador `++`
3. [`Expr.py`](https://github.com/AlanValdevenito/plox/blob/feature/postfix-increment-operator/plox/Expr.py): Se agrega la clase `PostfixExpr` que también hereda de `Expr`
4. [`Parser.py`](https://github.com/AlanValdevenito/plox/blob/feature/postfix-increment-operator/plox/Parser.py): Se agrega la regla productiva postfix para el parseo del operador `++`

Adicionalmente:
1. Se agregaron un par de test en el directorio [`tests/`](https://github.com/AlanValdevenito/plox/blob/feature/postfix-increment-operator/tests/test_scanner.py) para el escaneo del operador `++`
2. Se agregaron ejemplos en [`scanning.lox`](https://github.com/AlanValdevenito/plox/blob/feature/postfix-increment-operator/examples/scanning.lox) y [`parsing.lox`](https://github.com/AlanValdevenito/plox/blob/feature/postfix-increment-operator/examples/parsing.lox)

### Gramática

Nuestra gramática antes de los cambios era la siguiente:

```
unary          → ( "!" | "-" ) unary | call;
call           → primary ( "(" arguments? ")" )* ;
primary        → NUMBER | STRING | "true" | "false" | "nil" | "(" expression ")" | IDENTIFIER ;
```

Tras estos cambios, nuestra gramática es la siguiente:

```
unary          → ( "!" | "-" ) unary | postfix ;
postfix        → call ( "++" )* ;
call           → primary ( "(" arguments? ")" )* ;
primary        → NUMBER | STRING | "true" | "false" | "nil" | "(" expression ")" | IDENTIFIER ;
```

La regla productiva postfix tiene menos precedencia que call para evitar casos como el siguiente:

`func()++ debería parsearse como (func())++ y no como func()(++)`

La regla productiva postfix tiene mas precedencia que unary para evitar casos como el siguiente:

`-x++ deberia parsearse como -(x++) y no como (-x)++`

## Ejemplos

### Escaneo

Antes de los cambios el comportamiento era el siguiente:

<img width="878" height="173" alt="image" src="https://github.com/user-attachments/assets/e996b190-719a-4ea4-a69e-3eaba96c38ae" />

Despues de los cambios el comportamiento es el siguiente:

<img width="905" height="257" alt="image" src="https://github.com/user-attachments/assets/253c3bf5-3692-46a4-aee9-b2a7e31574a4" />

Ejecucion de los test agregados para el escaneo:

<img width="1332" height="260" alt="image" src="https://github.com/user-attachments/assets/42cdda85-56df-49ef-bae4-eb2da8466966" />

### Parseo

Antes de los cambios el comportamiento era el siguiente:

<img width="893" height="200" alt="image" src="https://github.com/user-attachments/assets/a87f7082-12b0-4801-a9ee-d0de599a14d9" />

Despues de los cambios el comportamiento es el siguiente:

<img width="863" height="197" alt="image" src="https://github.com/user-attachments/assets/22161153-8dd1-4611-9463-204ed15a3e1f" />
