### PR TITLE
Pretty Printer Fix

### DIFF
--- a/plox.py
+++ b/plox.py
@@ -17,7 +17,7 @@ try:
     promptsession = PromptSession(history=FileHistory(".plox_history"))
 
     def prompt_input():
-        return promptsession.prompt("> ")
+        return promptsession.prompt("\n> ")
 
 except ImportError:
 
@@ -25,7 +25,7 @@ except ImportError:
         return text
 
     def prompt_input():
-        return input("> ")
+        return input("\n> ")
 
 
 class Plox:

--- a/plox.py
+++ b/plox.py
@@ -17,7 +17,7 @@ try:
     promptsession = PromptSession(history=FileHistory(".plox_history"))
 
     def prompt_input():
-        return promptsession.prompt("\n> ")
+        return promptsession.prompt("> ")
 
 except ImportError:
 
@@ -25,7 +25,7 @@ except ImportError:
         return text
 
     def prompt_input():
-        return input("\n> ")
+        return input("> ")
 
 
 class Plox:

--- a/plox/PrettyPrinter.py
+++ b/plox/PrettyPrinter.py
@@ -62,10 +62,11 @@ class PrettyPrinter:
     # Printear por stdout el ast de forma más legible
     def print(self, stmts: list[Stmt]):
         for stmt in stmts:
-            self._reset()
             self._accept(stmt)
-            ast = self._prettify()
-            print(f"\n{ast}")
+
+        ast = self._prettify()
+        self._reset()
+        print(f"\n{ast}")
 
     @singledispatchmethod
     def _accept(self, obj: Expr | Stmt) -> None:

--- a/plox/PrettyPrinter.py
+++ b/plox/PrettyPrinter.py
@@ -1,6 +1,6 @@
 from enum import Enum, auto
 from functools import singledispatchmethod
-from typing import Callable
+from typing import Callable, Iterable
 from .Stmt import (
     BlockStmt,
     ExpressionStmt,
@@ -28,9 +28,9 @@ from .Expr import (
 
 # Indica una dirección, con una lista de ellas se puede reconstruir
 # el camino que atraveso el printer para llegar a cada expresión.
-class Dir(Enum):
-    LEFT = auto()
-    RIGHT = auto()
+class Branch(Enum):
+    MID = auto()
+    LAST = auto()
 
 
 class PrettyPrinter:
@@ -47,8 +47,8 @@ class PrettyPrinter:
         stmt_f: Callable[[str], str] = lambda x: x,
         type_f: Callable[[str], str] | None = None,
     ):
+        self._ofs = 0
         self._path = []
-        self._shift = 0
         self._branch_f = branch_f
         self._expr_f = expr_f
         self._stmt_f = stmt_f
@@ -63,7 +63,7 @@ class PrettyPrinter:
             self._reset()
             self._accept(stmt)
             ast = self._prettify()
-            print(ast, end="\n\n")
+            print(f"\n{ast}")
 
     @singledispatchmethod
     def _accept(self, obj: Expr | Stmt) -> None:
@@ -72,74 +72,81 @@ class PrettyPrinter:
     # ---------- Handlers de Statements ---------- #
 
     @_accept.register
+    def _(self, stmt: BlockStmt):
+        self._store_stmt("block:", "BlockStmt")
+        self._shift(stmt._statements)
+
+    @_accept.register
     def _(self, stmt: ExpressionStmt):
         self._accept(stmt._expression)
-
-    @_accept.register
-    def _(self, stmt: PrintStmt):
-        self._shifted("print", stmt, lambda: self._accept(stmt._expression))
-
-    @_accept.register
-    def _(self, stmt: BlockStmt):
-        for s in stmt._statements:
-            self._accept(s)
-
-    @_accept.register
-    def _(self, stmt: VarDecl):
-        tag = stmt._name.lexeme
-
-        def shifted():
-            if stmt._initializer:
-                self._accept(stmt._initializer)
-
-        self._shifted(tag, stmt, shifted)
 
     @_accept.register
     def _(self, stmt: FunDecl):
         name = stmt._name.lexeme
         parameters = ",".join(p.lexeme for p in stmt._parameters)
-        tag = f"{name}({parameters})"
+        tag = f"{name}({parameters}):"
 
-        def shifted():
-            for s in stmt._body:
-                self._accept(s)
-
-        self._shifted(tag, stmt, shifted)
-
-    @_accept.register
-    def _(self, stmt: ReturnStmt):
-        tag = "return"
-
-        def shifted():
-            if stmt._value:
-                self._accept(stmt._value)
-
-        self._shifted(tag, stmt, shifted)
+        self._store_stmt(tag, "FunDecl")
+        self._shift(stmt._body)
 
     @_accept.register
     def _(self, stmt: IfStmt):
-        self._shifted("if", stmt, lambda: self._accept(stmt._condition))
-        self._shifted("then", stmt._thenBranch, lambda: self._accept(stmt._thenBranch))
+        self._store_stmt("if:", "IfStmt(cond)")
+        self._shift([stmt._condition])
 
-        if stmt._elseBranch:
-            self._shifted(
-                "else",
-                stmt._elseBranch,
-                lambda: self._accept(stmt._elseBranch),
-            )
+        self._store_stmt("then:", "IfStmt(then)")
+        self._shift([stmt._thenBranch])
+
+        if else_branch := stmt._elseBranch:
+            self._store_stmt("else:", "IfStmt(else)")
+            self._shift([else_branch])
+
+    @_accept.register
+    def _(self, stmt: PrintStmt):
+        self._store_stmt("print:", "PrintStmt")
+        self._shift([stmt._expression])
+
+    @_accept.register
+    def _(self, stmt: ReturnStmt):
+        self._store_stmt("return:", "ReturnStmt")
+
+        if expr := stmt._value:
+            self._shift([expr])
+
+    @_accept.register
+    def _(self, stmt: VarDecl):
+        tag = stmt._name.lexeme
+        self._store_stmt(f"{tag}:", "VarDecl")
+
+        if init := stmt._initializer:
+            self._shift([init])
 
     @_accept.register
     def _(self, stmt: WhileStmt):
-        self._shifted("while", stmt, lambda: self._accept(stmt._condition))
-        self._shifted("do", stmt._body, lambda: self._accept(stmt._body))
+        self._store_stmt("while:", "WhileStmt(cond)")
+        self._shift([stmt._condition])
+
+        self._store_stmt("body:", "While(body)")
+        self._shift([stmt._body])
 
     # ---------- Handlers de Expresiones ---------- #
 
     @_accept.register
-    def _(self, expr: BinaryExpr | LogicExpr):
-        self._store(expr._operator.lexeme, expr)
-        self._branch(Dir.RIGHT, lambda: self._accept(expr._right))
-        self._branch(Dir.LEFT, lambda: self._accept(expr._left))
+    def _(self, expr: AssignmentExpr):
+        self._store_expr(expr._name.lexeme, "AssignmentExpr")
+        self._branch(Branch.LAST, [expr._value])
+
+    @_accept.register
+    def _(self, expr: BinaryExpr):
+        self._store_expr(expr._operator.lexeme, "BinaryExpr")
+        self._branch(Branch.MID, [expr._right])
+        self._branch(Branch.LAST, [expr._left])
+
+    @_accept.register
+    def _(self, expr: CallExpr):
+        self._store_expr("()", "CallExpr")
+        self._branch(Branch.MID, reversed(expr._arguments))
+        self._branch(Branch.LAST, [expr._callee])
 
     @_accept.register
     def _(self, expr: GroupingExpr):
@@ -152,73 +159,57 @@ class PrettyPrinter:
         else:
             tag = str(expr._value)
 
-        self._store(tag, expr)
+        self._store_expr(tag, "LiteralExpr")
 
     @_accept.register
-    def _(self, expr: UnaryExpr):
-        self._store(expr._operator.lexeme, expr)
-        self._branch(Dir.LEFT, lambda: self._accept(expr._right))
-
-    @_accept.register
-    def _(self, expr: CallExpr):
-        self._accept(expr._callee)
-
-        # Como el nombre de la función es una expresión le
-        # cambio el tipo a callee de `VariableExpr` a `CallExpr`
-        padding, tag, _, f = self._entries[-1]
-        cls_name = expr.__class__.__name__
-        self._entries[-1] = padding, tag, cls_name, f
-
-        if args := expr._arguments:
-
-            def shifted():
-                for arg in reversed(args[1:]):
-                    self._accept(arg)
-
-            self._branch(Dir.RIGHT, shifted)
-            self._branch(Dir.LEFT, lambda: self._accept(args[0]))
-
-    @_accept.register
-    def _(self, expr: VariableExpr):
-        self._store(expr._name.lexeme, expr)
-
-    @_accept.register
-    def _(self, expr: AssignmentExpr):
-        self._store(expr._name.lexeme, expr)
-        self._branch(Dir.LEFT, lambda: self._accept(expr._value))
+    def _(self, expr: LogicExpr):
+        self._store_expr(expr._operator.lexeme, "LogicExpr")
+        self._branch(Branch.MID, [expr._right])
+        self._branch(Branch.LAST, [expr._left])
 
     @_accept.register
     def _(self, expr: PostfixExpr):
-        self._store(expr._operator.lexeme, expr)
-        self._branch(Dir.LEFT, lambda: self._accept(expr._left))
+        self._store_expr(expr._operator.lexeme, "PostfixExpr")
+        self._branch(Branch.LAST, [expr._left])
+
+    @_accept.register
+    def _(self, expr: UnaryExpr):
+        self._store_expr(expr._operator.lexeme, "UnaryExpr")
+        self._branch(Branch.LAST, [expr._right])
+
+    @_accept.register
+    def _(self, expr: VariableExpr):
+        self._store_expr(expr._name.lexeme, "VariableExpr")
 
     # ---------- Helpers ---------- #
 
-    # Guarda una entrada en el arreglo
-    def _store(self, tag: str, obj: Expr | Stmt):
+    # Guarda una entrada de statement en el arreglo
+    def _store_stmt(self, tag: str, name: str):
         padding = self._make_padding()
-        cls_name = obj.__class__.__name__
+        self._entries.append((padding, tag, name, self._stmt_f))
 
-        if isinstance(obj, Expr):
-            f = self._expr_f
-        else:
-            tag += ":"
-            f = self._stmt_f
-
-        self._entries.append((padding, tag, cls_name, f))
+    # Guarda una entrada de expresión en el arreglo
+    def _store_expr(self, tag: str, name: str):
+        padding = self._make_padding()
+        self._entries.append((padding, tag, name, self._expr_f))
 
     # Guarda el nodo actual, mueve el arbol hacia la derecha en una unidad
     # de offset y evalua la función pasada como argumento
-    def _shifted(self, tag: str, stmt: Stmt, f: Callable[[], None]):
-        self._store(tag, stmt)
-        self._shift += 1
-        f()
-        self._shift -= 1
+    def _shift(self, visits: Iterable[Stmt | Expr]):
+        self._ofs += 1
+
+        for visitable in visits:
+            self._accept(visitable)
+
+        self._ofs -= 1
 
     # Evalua la función pasada por parametro habiendose movido en cierta dirección
-    def _branch(self, direction: Dir, f: Callable[[], None]):
-        self._path.append(direction)
-        f()
+    def _branch(self, branch: Branch, visits: Iterable[Stmt | Expr]):
+        self._path.append(branch)
+
+        for visitable in visits:
+            self._accept(visitable)
+
         self._path.pop()
 
     # Arma el padding para una cierta rama del ast
@@ -227,18 +218,18 @@ class PrettyPrinter:
 
         if self._path:
             for dir in self._path[:-1]:
-                if dir == Dir.RIGHT:
+                if dir == Branch.MID:
                     parts.append("│   ")
                 else:
                     parts.append("    ")
 
             last = self._path[-1]
-            if last == Dir.RIGHT:
+            if last == Branch.MID:
                 parts.append("├── ")
             else:
                 parts.append("└── ")
 
-        return " " * (4 * self._shift) + "".join(parts)
+        return " " * (4 * self._ofs) + "".join(parts)
 
     # Aplica las funciones provistas en el constructuor a un entry
     def _apply(

--- a/plox/PrettyPrinter.py
+++ b/plox/PrettyPrinter.py
@@ -129,7 +129,7 @@ class PrettyPrinter:
         self._store_stmt("while:", "WhileStmt(cond)")
         self._shift([stmt._condition])
 
-        self._store_stmt("body:", "While(body)")
+        self._store_stmt("body:", "WhileStmt(body)")
         self._shift([stmt._body])
 
     # ---------- Handlers de Expresiones ---------- #
@@ -153,7 +153,7 @@ class PrettyPrinter:
 
     @_accept.register
     def _(self, expr: GroupingExpr):
-        self._store_expr("()", "Grouping")
+        self._store_expr("()", "GroupingExpr")
         self._branch(Branch.LAST, [expr._expression])
 
     @_accept.register

--- a/plox/PrettyPrinter.py
+++ b/plox/PrettyPrinter.py
@@ -34,6 +34,8 @@ class Branch(Enum):
 
 
 class PrettyPrinter:
+    OFS_SIZE = 4
+
     # Aplica funciones distintas a los distintos tipos de nodos. Aplica:
     #   - branch_f: Al padding que tiene las ramas de los arboles de expresiones
     #   - expr_f:   A los nodos de expresiones
@@ -144,13 +146,14 @@ class PrettyPrinter:
 
     @_accept.register
     def _(self, expr: CallExpr):
-        self._store_expr("()", "CallExpr")
+        self._store_expr("@", "CallExpr")
         self._branch(Branch.MID, reversed(expr._arguments))
         self._branch(Branch.LAST, [expr._callee])
 
     @_accept.register
     def _(self, expr: GroupingExpr):
-        return self._accept(expr._expression)
+        self._store_expr("()", "Grouping")
+        self._branch(Branch.LAST, [expr._expression])
 
     @_accept.register
     def _(self, expr: LiteralExpr):
@@ -196,12 +199,12 @@ class PrettyPrinter:
     # Guarda el nodo actual, mueve el arbol hacia la derecha en una unidad
     # de offset y evalua la función pasada como argumento
     def _shift(self, visits: Iterable[Stmt | Expr]):
-        self._ofs += 1
+        self._ofs += self.OFS_SIZE
 
         for visitable in visits:
             self._accept(visitable)
 
-        self._ofs -= 1
+        self._ofs -= self.OFS_SIZE
 
     # Evalua la función pasada por parametro habiendose movido en cierta dirección
     def _branch(self, branch: Branch, visits: Iterable[Stmt | Expr]):
@@ -229,7 +232,7 @@ class PrettyPrinter:
             else:
                 parts.append("└── ")
 
-        return " " * (4 * self._ofs) + "".join(parts)
+        return " " * self._ofs + "".join(parts)
 
     # Aplica las funciones provistas en el constructuor a un entry
     def _apply(

--- a/plox/PrettyPrinter.py
+++ b/plox/PrettyPrinter.py
@@ -66,7 +66,7 @@ class PrettyPrinter:
 
         ast = self._prettify()
         self._reset()
-        print(f"\n{ast}")
+        print(f"\n{ast}\n")
 
     @singledispatchmethod
     def _accept(self, obj: Expr | Stmt) -> None:


### PR DESCRIPTION
# Cosas nuevas

## 1. Ahora los `BlockStmt` se printean, no se porque antes no lo hice.
```console
> var a = 10; { var a = 20; print a; } print a;

VarDecl       a:
LiteralExpr       10.0
BlockStmt     block:
VarDecl           a:
LiteralExpr           20.0
PrintStmt         print:
VariableExpr          a
PrintStmt     print:
VariableExpr      a
```

## 2. Lo mismo para los `GroupingExpr`.

Para estos no era necesario porque ya se veía en la estructura del árbol, pero así es más explícito.

```console
> (10 + 20) * (5 + 10 + 15);

BinaryExpr   *
Grouping     ├── ()
BinaryExpr   │   └── +
LiteralExpr  │       ├── 15.0
BinaryExpr   │       └── +
LiteralExpr  │           ├── 10.0
LiteralExpr  │           └── 5.0
Grouping     └── ()
BinaryExpr       └── +
LiteralExpr          ├── 20.0
LiteralExpr          └── 10.0
```

## 3. Los `CallExpr` ahora se printean con @ como tag.

Anteriormente se asumía que el `callee` era una `VariableExpr` por lo que terminaba siendo un identificador. Si se encadenaban funciones como `f(10)(20)(30)` printeaba cualquier cosa.

Notar que ahora las ramas son los argumentos y la última es el `callee`, si se necesitara resolver `callee` porque es otra expresión, esa rama tendrá más subramas.

```console
> fun fib(n) { if (n <= 1) return n; return fib(n - 1) + fib(n - 2); }

FunDecl       fib(n):
IfStmt(cond)      if:
BinaryExpr            <=
LiteralExpr           ├── 1.0
VariableExpr          └── n
IfStmt(then)      then:
ReturnStmt            return:
VariableExpr              n
ReturnStmt        return:
BinaryExpr            +
CallExpr              ├── @
BinaryExpr            │   ├── -
LiteralExpr           │   │   ├── 2.0
VariableExpr          │   │   └── n
VariableExpr          │   └── fib
CallExpr              └── @
BinaryExpr                ├── -
LiteralExpr               │   ├── 1.0
VariableExpr              │   └── n
VariableExpr              └── fib
```

# Arreglos de bugs

## 1. Ahora `callee` de `CallExpr` se printea bien incluso si no es un `VariableExpr`.
```console
> for (var i = 0; i < 10; i++) { print f(i)(i * 2)(i * 4); }

BlockStmt        block:
VarDecl              i:
LiteralExpr              0.0
WhileStmt(cond)      while:
BinaryExpr               <
LiteralExpr              ├── 10.0
VariableExpr             └── i
While(body)          body:
BlockStmt                block:
BlockStmt                    block:
PrintStmt                        print:
CallExpr                             @
BinaryExpr                           ├── *
LiteralExpr                          │   ├── 4.0
VariableExpr                         │   └── i
CallExpr                             └── @
BinaryExpr                               ├── *
LiteralExpr                              │   ├── 2.0
VariableExpr                             │   └── i
CallExpr                                 └── @
VariableExpr                                 ├── i
VariableExpr                                 └── f
PostfixExpr                  ++
VariableExpr                 └── i
```

# Notas

Cambié un poco la implementación porque creo que ahora se entiende mejor.