### PR TITLE
Feature/operador ternario

### DIFF
--- a/examples/ternary_operator.lox
+++ b/examples/ternary_operator.lox
@@ -1,0 +1,66 @@
+// Para correr en la terminal: ./plox.py --line-by-line examples/ternary_operator.lox
+
+
+// Uso basico del operador
+print true ? 1 : 2;          // 1
+print false ? "a" : "b";     // b
+
+
+// Unicamente el valor nil y false se consideran falsy
+print nil ? condicion_es_truthy : "condicion_es_falsy";  // condicion_es_falsy
+print 0 ? "condicion_es_truthy" : "condicion_es_falsy";  // condicion_es_truthy
+
+
+// El resultado del operador puede ser asignado
+var a = true ? 1 : 2;
+print a;  // 1
+
+
+// Se permite que ambas ramas sean asignaciones
+var x = 0;
+true ? x = 10 : x = 20;
+print x;  // 10
+
+var y = 0;
+false ? y = 10 : y = 20;
+print y;  // 20
+
+
+// Se asocia de derecha a izquierda
+// a ? b : c ? d : e  ==>  a ? b : (c ? d : e)
+
+print true ? 1 : false ? 2 : 3;   // 1
+print false ? 1 : true ? 2 : 3;   // 2
+print false ? 1 : false ? 2 : 3;  // 3
+
+
+// conditional → logic_or ( "?" assignment ":" assignment )? ;
+// => El ternario tiene menor precedencia que logic_or y mayor que assignment
+
+// Con OR. La agrupacion es por ejemplo: (bool1 or bool2) ? ... : ... 
+print false or true ? 1 : 2;   // 1
+
+// Con asignación. La agrupacion es: var z = (cond ? ... : ...);
+var z = false ? 1 : 2;
+print z; // 2
+
+
+//Errores
+
+// Falta ';'
+print true ? 1 : 2
+
+// Falta ':'
+print true ? 1;
+
+// ':' sin '?'
+print true 1 : 2;
+
+// Falta rama true
+print true ? : 2;
+
+// Falta rama false
+print true ? 1 : ;
+
+// Falta expresion de condicion
+print ? 1 : 2;

--- a/plox/Expr.py
+++ b/plox/Expr.py
@@ -97,3 +97,13 @@ class PostfixExpr(Expr):
 
     def __repr__(self) -> str:
         return f"Postfix: [{self._left} {self._operator.lexeme}]"
+
+# ternary        → expresion "?" expression ":" expression ;
+class TernaryExpr(Expr):
+    def __init__(self, condition: Expr, true_branch: Expr, false_branch: Expr):
+        self._condition = condition
+        self._true_branch = true_branch
+        self._false_branch = false_branch
+
+    def __repr__(self) -> str:
+        return f"Ternary: [{self._condition} ? {self._true_branch} : {self._false_branch}]"

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -21,6 +21,7 @@ from .Expr import (
     AssignmentExpr,
     LogicExpr,
     CallExpr,
+    TernaryExpr,
 )
 from .Function import Function, ReturnValue
 from .Token import TokenType
@@ -328,6 +329,16 @@ class Interpreter(object):
             )
 
         return callee(self, arguments)
+    
+    @evaluate.register
+    def _(self, expression: TernaryExpr):
+        condition = self.evaluate(expression._condition)
+        if self.is_truthy(condition):
+            # si condition es truthy, evaluamos la rama verdadera
+            return self.evaluate(expression._true_branch)
+        else:
+            # si condition es falsy, evaluamos la rama falsa
+            return self.evaluate(expression._false_branch)
 
     # ---------- Helpers ---------- #
 

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -336,9 +336,9 @@ class Interpreter(object):
         if self.is_truthy(condition):
             # si condition es truthy, evaluamos la rama verdadera
             return self.evaluate(expression._true_branch)
-        else:
-            # si condition es falsy, evaluamos la rama falsa
-            return self.evaluate(expression._false_branch)
+        
+        # si condition es falsy, evaluamos la rama falsa
+        return self.evaluate(expression._false_branch)
 
     # ---------- Helpers ---------- #
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -329,9 +329,9 @@ class Parser(object):
     def expression(self) -> Expr:
         return self.assignment()
 
-    # assignment     → IDENTIFIER "=" assignment | logic_or ;
+    # assignment     → IDENTIFIER "=" assignment | conditional ;
     def assignment(self) -> Expr:
-        expr = self.logic_or()
+        expr = self.conditional() # una conditional tiene mayor precedencia que una asignacion
 
         # Solo se puede asignar sobre variables. Si no, es un error
         if self._match(TokenType.EQUAL):
@@ -342,6 +342,30 @@ class Parser(object):
 
             value = self.assignment()
             return AssignmentExpr(expr._name, value)
+
+        return expr
+
+    # conditional   → logic_or ( "?" assignment ":" assignment )? ;
+    # El ternario tiene menor precedencia que logic_or (y todo lo que está por encima de logic_or)
+    # y mayor precedencia que la asignación. Por eso vive entre assignment y logic_or.
+    def conditional(self) -> Expr:
+        expr = self.logic_or()
+
+        # Si me crucé un "?", parseo las dos branches de la expresión ternaria
+        if self._match(TokenType.QUESTION):
+
+            # permitimos que la branch true pueda ser otra asignacion
+            true_branch = self.assignment()
+            if not self._match(TokenType.COLON):
+
+                # si no me crucé un ":", tengo un error
+                raise SyntaxError(
+                    f"Expected ':' after ternary true-branch, got `{self._lookahead()}` instead"
+                )
+            
+            # permitimos que la branch false pueda ser otra asignacion
+            false_branch = self.assignment()
+            expr = TernaryExpr(expr, true_branch, false_branch)
 
         return expr
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -10,6 +10,7 @@ from .Expr import (
     LogicExpr,
     CallExpr,
     PostfixExpr,
+    TernaryExpr,
 )
 from .Stmt import (
     Stmt,

--- a/plox/Resolver.py
+++ b/plox/Resolver.py
@@ -22,6 +22,7 @@ from .Expr import (
     AssignmentExpr,
     LogicExpr,
     CallExpr,
+    TernaryExpr,
 )
 
 
@@ -184,3 +185,9 @@ class Resolver(object):
         self.resolve(expression._callee)
         for arg in expression._arguments:
             self.resolve(arg)
+
+    @resolve.register
+    def _(self, expression: TernaryExpr):
+        self.resolve(expression._condition)
+        self.resolve(expression._true_branch)
+        self.resolve(expression._false_branch)

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -102,7 +102,6 @@ class Scanner(object):
                         raise Exception(f"Unterminated comment: `{self.lexeme()}`")
                 else:
                     self.add_token(TokenType.SLASH)
-
             # tokens de uno o dos caracteres
             case "+":
                 self.add_token(
@@ -124,6 +123,12 @@ class Scanner(object):
                 self.add_token(
                     TokenType.GREATER_EQUAL if self._match("=") else TokenType.GREATER
                 )
+
+            case "?":
+                self.add_token(TokenType.QUESTION)
+
+            case ":":
+                self.add_token(TokenType.COLON)
 
             case '\'':
                 # consumimos la cadena hasta el proximo ' o hasta el fin de linea

--- a/plox/Token.py
+++ b/plox/Token.py
@@ -31,6 +31,8 @@ class TokenType(Enum):
     GREATER_EQUAL = auto()
     LESS = auto()
     LESS_EQUAL = auto()
+    QUESTION = auto()
+    COLON = auto()
 
     # literales
     IDENTIFIER = auto()


### PR DESCRIPTION
##  Descripción del cambio
Este PR agrega soporte para el **operador ternario** (`cond ? expr1 : expr2`) al intérprete de **Plox**.  

---

##  Tokens
- Se agregaron dos nuevos tokens de un solo carácter:  
  - `QUESTION (?) `
  - `COLON (:)`

---

##  Scanner
- Se incorporó el reconocimiento de `?` y `:`.  
- **No se usa lookahead** ya que son tokens de un solo carácter.  
- En si para esta etapa el significado de la combinación de estos caracteres no es de interés, sino que se delega al **parser**.  

---

## Parser
- Se ajustaron las reglas de expresión para que el orden de precedencia se mantenga consistente, particularmente el objetivo era que una expresión **conditional** tenga mayor prioridad ante **assignment** pero menor ante el resto de expresiones al momento.  
  ```ebnf
  assignment  → IDENTIFIER "=" assignment | conditional ;
  conditional → logic_or ( "?" assignment ":" assignment )? ;
- Se agregó el nodo `TernaryExpr`
- La asociatividad de derecha a izquierda
---

## Interpreter
- Al momento de evaluar la expresión `TernaryExpr` se hace de forma **lazy**, es decir unicamente se va a evaluar la rama que corresponda dependiendo de la si la condición es **truthy** o **falsy**

---

## Algunos Ejemplos de Uso
 ```ebnf
print true ? 1 : 2;              // 1
print false ? "a" : "b";         // "b"
print false ? 1 : true ? 2 : 3;  // 2