### PR TITLE
feat (interpreter): postfix increment operator

### DIFF
--- a/examples/increment_operator.lox
+++ b/examples/increment_operator.lox
@@ -1,0 +1,15 @@
+// Para correr en la terminal: ./plox.py --line-by-line examples/increment_operator.lox
+
+// Postfix ++ (devuelve el valor viejo, incrementa despues)
+
+var x = 5;
+var value = x++;                 // devuelve el valor viejo, x pasa a 6
+print(value);                    // imprime 5
+print(x);                        // imprime 6
+
+// Prefix ++ (incrementa primero, despues devuelve el nuevo valor)
+
+var x = 5;
+var value = ++x;                 // x pasa a 6, devuelve el nuevo valor
+print(value);                    // imprime 6
+print(x);                        // imprime 6

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -354,14 +354,14 @@ class Interpreter(object):
             get_value = lambda: self.globals.get(left._name.lexeme)
             assign_value = lambda new_value: self.globals.assign(left._name.lexeme, new_value)
 
-        old_value = get_value() # la funcion lamba para obtener el valor viejo depende de si la variable se encuentra en nuestro diccionario de scope local o no
+        old_value = get_value() # la funcion lambda para obtener el valor viejo depende de si la variable se encuentra en nuestro diccionario de scope local o no
 
         # el operador ++ solo funciona sobre números
         if not self.is_number(old_value):
             raise RuntimeError(f"Operand of ++ must be a number, got: `{old_value}++`")
 
         new_value = old_value + 1
-        assign_value(new_value)# la funcion lamba para asignar el valor nuevo depende de si la variable se encuentra en nuestro diccionario de scope local o no
+        assign_value(new_value) # la funcion lambda para asignar el valor nuevo depende de si la variable se encuentra en nuestro diccionario de scope local o no
 
         # devolvemos el valor viejo
         return old_value

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -489,8 +489,7 @@ class Parser(object):
         # primero chequeamos lo que tenemos a la izquierda, y después seguimos
         expr = self.call()
 
-        # mientras nos crucemos ++
-        while not self._is_at_end() and self._match(TokenType.PLUS_PLUS):
+        if self._match(TokenType.PLUS_PLUS):
             # obtenemos el token ++ que acabamos de consumir
             plus_plus_token = self._previous()
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -453,7 +453,7 @@ class Parser(object):
 
         return expr
 
-    # unary          → ( "!" | "-" ) unary | postfix ;
+    # unary          → ( "!" | "-" | "++" ) unary | postfix ;
     def unary(self) -> Expr:
         # a diferencia de las reglas de expresiones binarias,
         # acá el operador es un prefijo.
@@ -462,6 +462,23 @@ class Parser(object):
             operator = self._previous()
             right = self.unary()
             return UnaryExpr(operator, right)
+        
+        if self._match(TokenType.PLUS_PLUS):
+            operator = self._previous()
+            right = self.unary()
+
+            # solo se puede aplicar ++ sobre variables. Si no tenemos una variable, es un error
+            if not isinstance(right, VariableExpr):
+                raise SyntaxError(
+                    f"Invalid prefix target, got `{self._lookahead()}` instead"
+                )
+            
+            # usamos el operador ++ como un syntatic sugar de una suma: x = x + 1
+            # lo parseamos como una asignación para modificar el valor de la variable
+            return AssignmentExpr(
+                right._name,
+                BinaryExpr(right, Token(TokenType.PLUS, lexeme="+", literal=None, line=self._previous().line), LiteralExpr(1))
+            )
 
         # Si no tuve recursividad de unarios, entonces tengo una llamada a un prefijo
         return self.postfix()
@@ -474,19 +491,8 @@ class Parser(object):
 
         # mientras nos crucemos ++
         while not self._is_at_end() and self._match(TokenType.PLUS_PLUS):
-            
-            # solo se puede aplicar ++ sobre variables. Si no tenemos una variable, es un error
-            if not isinstance(expr, VariableExpr):
-                raise SyntaxError(
-                    f"Invalid postfix target, got `{self._lookahead()}` instead"
-                )
-            
-            # usamos el operador ++ como un syntatic sugar de una suma: x = x + 1
-            # lo parseamos como una asignación para modificar el valor de la variable
-            expr = AssignmentExpr(
-                expr._name,
-                BinaryExpr(expr, Token(TokenType.PLUS, lexeme="+", literal=None, line=self._previous().line), LiteralExpr(1))
-            )
+            operator = self._previous()
+            expr = PostfixExpr(expr, operator)
 
         return expr
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -491,8 +491,18 @@ class Parser(object):
 
         # mientras nos crucemos ++
         while not self._is_at_end() and self._match(TokenType.PLUS_PLUS):
-            operator = self._previous()
-            expr = PostfixExpr(expr, operator)
+            # obtenemos el token ++ que acabamos de consumir
+            plus_plus_token = self._previous()
+
+            # solo se puede aplicar ++ sobre variables. Si no tenemos una variable, es un error
+            if not isinstance(expr, VariableExpr):
+                raise SyntaxError(
+                    f"Invalid prefix target, got `{self._lookahead()}` instead"
+                )
+
+            # representamos el post-increment como un nodo PostfixExpr
+            # el interprete se encarga despues de devolver el valor viejo y después incrementar
+            expr = PostfixExpr(expr, plus_plus_token)
 
         return expr
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -483,7 +483,7 @@ class Parser(object):
         # Si no tuve recursividad de unarios, entonces tengo una llamada a un prefijo
         return self.postfix()
 
-    # postfix        → call ( "++" )* ;
+    # postfix        → call ( "++" )? ;
     def postfix(self) -> Expr:
         # acá el operador es un sufijo
         # primero chequeamos lo que tenemos a la izquierda, y después seguimos

--- a/plox/Resolver.py
+++ b/plox/Resolver.py
@@ -23,6 +23,7 @@ from .Expr import (
     LogicExpr,
     CallExpr,
     TernaryExpr,
+    PostfixExpr,
 )
 
 
@@ -191,3 +192,7 @@ class Resolver(object):
         self.resolve(expression._condition)
         self.resolve(expression._true_branch)
         self.resolve(expression._false_branch)
+
+    @resolve.register
+    def _(self, expr: PostfixExpr):
+        self.resolve(expr._left)


### PR DESCRIPTION
# Agregado del operador x++ (**_continuación_**)

## Resumen

Se agrega como interpretar el operador de post-incremento `++` a Plox.

Adicionalmente, se agrega el parseo del operador de pre-incremento `++`.

## Cambios realizados

### Commit [bd27671](https://github.com/AlanValdevenito/plox/commit/bd27671afd7bb0c485a77902486128342ab3d922)

Siguiendo con la idea propuesta en el PR anterior, se uso el operator como un syntatic sugar de una suma.

Se parseo el operador como una asignación `x = x + 1` para modificar el valor de la variable.

### Commit [f6de721](https://github.com/AlanValdevenito/plox/commit/f6de721dc4cae93c61e83b2f7003c9fa55d5ed17)

Comparando como se comportan los operadores de pre-incremento y post-incremento en C

<img width="1319" height="321" alt="image" src="https://github.com/user-attachments/assets/a62b8d96-5336-4cc7-a05c-5be394732c8d" />

me di cuenta que el comportamiento que tenia el operador como syntactic sugar de una suma era como pre-incremento y no como post-incremento:

<img width="821" height="175" alt="COMMIT 1" src="https://github.com/user-attachments/assets/df4185a5-5427-4e86-9d34-d9bc26afead3" />

Teniendo en cuenta esto, agregue el parseo del operador de pre-incremento `++` en la regla productiva `unary` parseandolo como una asignación `x = x + 1`:

<img width="777" height="182" alt="COMMIT 2" src="https://github.com/user-attachments/assets/adf1b002-a9c3-49a1-b8d6-6a01319b9e99" />

### Commit [a5892c1](https://github.com/AlanValdevenito/plox/commit/a5892c1fa33ce512f2b2c1c3940625ced1b075df)

Se agrega la resolución de PostfixExpr al `Resolver`.

### Commit [377d0ec](https://github.com/AlanValdevenito/plox/commit/377d0ecfb0b61143501302b83d46d4d5187ad01a)

Se agrego como interpretar expresiones de PostfixExpr al `Interpreter`. 

En la implementación primero nos guardamos en una variable el valor viejo, después asignamos el nuevo valor (sumando 1) y devolvemos el valor viejo.

De esta forma el operador se comporta como post-incremento devolviendo el valor viejo y luego incrementando:

<img width="1398" height="311" alt="image" src="https://github.com/user-attachments/assets/76afb4f7-0ff7-4a8d-b873-6e552be09ea7" />

## Ejemplos

Adicionalmente se agregaron ejemplos en [increment_operator.lox](https://github.com/AlanValdevenito/plox/blob/feature/postfix-increment-operator/examples/increment_operator.lox).

<img width="1174" height="360" alt="COMMIT 4" src="https://github.com/user-attachments/assets/662afac5-322b-4115-9188-75399a8bdbee" />