### PR TITLE
Feature: manejo de la división por cero

### DIFF
--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -251,6 +251,8 @@ class Interpreter(object):
                     raise RuntimeError(
                         f"Operands of / must be numbers, got: `{left} / {right}`"
                     )
+                elif right == 0:
+                    raise RuntimeError(f"Division by {right} is not allowed")
                 return left / right
             case TokenType.PERCENT:
                 if not self.is_number(left, right):


### PR DESCRIPTION
# Resumen
Se lanza un error de Lox cuando se detecta que el divisor es cero.

# Motivación
Es un cambio muy sutil, podría incluso ignorarse ya que el tipo de error es el mismo, pero si se detecta antes de intentar el cómputo se puede devolver un error de Lox.

# Decisión de diseño
- El chequeo debe hacerse en la etapa de ejecución dentro del propio intérprete. Habiendo chequeado en la misma que ambos operandos sean numéricos, ahora se inspecciona right (divisor) y, si es 0, lanzar un RuntimeError.

- Etapas previas no tienen la información necesaria: el scanner solo ve caracteres y construye tokens; el parser arma el AST a partir de esos tokens. Ninguno conoce los valores que resultan de evaluar las expresiones, de modo que cualquier manejo semántico como la división por cero pertenece al Interpreter.

# Antes
``` bash 
$ python plox.py 
> 1 / 0;
Runtime Error: float division by zero
```

# Ahora
``` bash 
$ python plox.py 
> 1 / 0;
Runtime Error: Division by 0.0 is not allowed
```