### PR TITLE
Feat: String indexing

### DIFF
--- a/examples/string_indexing.lox
+++ b/examples/string_indexing.lox
@@ -20,6 +20,12 @@ print a[2][0]; // l
 var index = 2;
 print "hola"[index]; // l
 
+// Iterar sobre un string
+var original = "un string";
+var reconstruido = "";
+for (var i = 0; i < len(original); i = i + 1) reconstruido = reconstruido + original[i];
+print reconstruido; // un string
+
 // Errores
 
 // Indice fuera de rango

--- a/examples/string_indexing.lox
+++ b/examples/string_indexing.lox
@@ -1,0 +1,35 @@
+// run in --line-by-line mode!!
+
+// Uso básico
+
+print "hola"[0]; // h
+print "hola"[3]; // a
+
+// Permite uso sobre cualquier primary o call (que se evalúe a string)
+var x = "un string";
+print x[1]; // n
+
+fun nombre() { return "plox"; } print nombre()[0]; // p
+
+// Incluso sobre otro indice
+var a = "hola";
+print a[2][0]; // l
+
+// Cualquier expresión que resuelva a un entero positivo es aceptada como índice
+
+var index = 2;
+print "hola"[index]; // l
+
+// Errores
+
+// Indice fuera de rango
+print "hola"[5];
+
+// El indice no es entero
+print "hola"[0.3];
+
+// El indice es negativo
+print "hola"[-1];
+
+// El indice no es un número
+print "hola"["1"];

--- a/plox/BuiltinFunctions.py
+++ b/plox/BuiltinFunctions.py
@@ -50,3 +50,22 @@ class TypeFunction(BuiltinFunction):
             return "function"
         else:
             return "unknown"
+
+class LenFunction(BuiltinFunction):
+    """Built-in function that returns the len of a string"""
+
+    def __init__(self):
+        super().__init__(arity=1, name="len", params="value")
+
+    def __call__(self, interpreter: "Interpreter", arguments: list):
+        """
+        Return the length of the first argument if it is a string
+        Raises an error if the argument is not a string
+        """
+
+        value = arguments[0]
+        if not interpreter.is_string(value):
+            raise RuntimeError(f"Argument of `len` must be a string, got: {value}")
+
+        return len(value)
+

--- a/plox/Expr.py
+++ b/plox/Expr.py
@@ -76,6 +76,16 @@ class CallExpr(Expr):
         return f"fn<{self.callee}({args})>"
 
 
+# index          → primary "[" expression "]" ;
+class IndexExpr(Expr):
+    def __init__(self, target: Expr, index: Expr):
+        self.target = target
+        self.index = index
+
+    def __repr__(self) -> str:
+        return f"<{self.target}[{self.index}]>"
+
+
 # variable       → IDENTIFIER ;
 class VariableExpr(Expr):
     def __init__(self, name: Token):

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -379,13 +379,15 @@ class Interpreter(object):
 
         index = self.evaluate(expression.index)
 
-        # Revisamos que se esté usando un número de índice y que el mismo no tenga parte fraccionaria
+        # Revisamos que se esté usando un número de índice y que el mismo no tenga parte fraccionaria ni sea negativo
         if not self.is_number(index) or int(index) != index or index < 0:
             raise RuntimeError(
                 f"Index must be a positive whole number, got: `{index}`"
             )
 
         index = int(index)
+
+        # Revisamos que no esté fuera de rango
         if index >= len(target):
             raise RuntimeError(
                 f"Index out of range (len: {len(target)}, index: {index})"

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -30,7 +30,7 @@ from .Expr import (
 from .Function import Function, ReturnValue
 from .Token import TokenType
 from .Env import Env
-from .BuiltinFunctions import TypeFunction
+from .BuiltinFunctions import TypeFunction, LenFunction
 
 
 class Interpreter(object):
@@ -65,6 +65,7 @@ class Interpreter(object):
     # Incorpora al intérprete funciones nativas
     def _populate_native_functions(self):
         self.globals.define("type", TypeFunction())
+        self.globals.define("len", LenFunction())
 
     # ---------- Ejecutadores de Statements ---------- #
 

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -380,13 +380,13 @@ class Interpreter(object):
         index = self.evaluate(expression.index)
 
         # Revisamos que se esté usando un número de índice y que el mismo no tenga parte fraccionaria
-        if not self.is_number(index) or int(index) != index:
+        if not self.is_number(index) or int(index) != index or index < 0:
             raise RuntimeError(
-                f"Index must be a round number, got: `{index}`"
+                f"Index must be a positive whole number, got: `{index}`"
             )
 
         index = int(index)
-        if index > len(target):
+        if index >= len(target):
             raise RuntimeError(
                 f"Index out of range (len: {len(target)}, index: {index})"
             )

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -382,7 +382,13 @@ class Interpreter(object):
         # Revisamos que se esté usando un número de índice y que el mismo no tenga parte fraccionaria
         if not self.is_number(index) or int(index) != index:
             raise RuntimeError(
-                f"Cannot use a non-round number as index, got: `{index}`"
+                f"Index must be a round number, got: `{index}`"
+            )
+
+        index = int(index)
+        if index > len(target):
+            raise RuntimeError(
+                f"Index out of range (len: {len(target)}, index: {index})"
             )
 
         return target[int(index)]

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -23,6 +23,7 @@ from .Expr import (
     AssignmentExpr,
     LogicExpr,
     CallExpr,
+    IndexExpr,
     TernaryExpr,
     PostfixExpr,
 )
@@ -364,6 +365,27 @@ class Interpreter(object):
             )
 
         return callee(self, arguments)
+
+    @evaluate.register
+    def _(self, expression: IndexExpr):
+        target = self.evaluate(expression.target)
+
+        # Si lo que se trata de indexar no es un string, levantamos un error
+        # A futuro, en caso de que mas tipos sean indexables, habría que extender el chequeo
+        if not self.is_string(target):
+            raise RuntimeError(
+                f"Only strings support indexing, got: `{target}`"
+            )
+
+        index = self.evaluate(expression.index)
+
+        # Revisamos que se esté usando un número de índice y que el mismo no tenga parte fraccionaria
+        if not self.is_number(index) or int(index) != index:
+            raise RuntimeError(
+                f"Cannot use a non-round number as index, got: `{index}`"
+            )
+
+        return target[int(index)]
 
     @evaluate.register
     def _(self, expression: TernaryExpr):

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -10,6 +10,7 @@ from .Expr import (
     AssignmentExpr,
     LogicExpr,
     CallExpr,
+    IndexExpr,
     PostfixExpr,
     TernaryExpr,
 )
@@ -542,35 +543,51 @@ class Parser(object):
 
         return expr
 
-    # call           → primary ( "(" arguments? ")" )* ;
+    # call           → primary ( ("(" arguments? ")")  | "[" expression "]")* ;
     # arguments      → expression ( "," expression )* ;
     def call(self) -> Expr:
         expr = self.primary()
 
         # Si me cruzo un paréntesis abierto, tengo una llamada a función
         # y tengo que parsear los argumentos
-        while self._match(TokenType.LEFT_PAREN):
-            arguments: list[Expr] = []
+        while True:
+            if self._match(TokenType.LEFT_PAREN):
+                arguments: list[Expr] = []
 
-            # Mientras no me cruce un paréntesis de cierre, sigo parseando argumentos
-            while (
-                not self._is_at_end()
-                and self._lookahead().token_type != TokenType.RIGHT_PAREN
-            ):
-                # Consumo el primer argumento
-                arguments.append(self.expression())
-
-                # Consumo un argumento por cada coma que tengo adelante
-                while not self._is_at_end() and self._match(TokenType.COMMA):
+                # Mientras no me cruce un paréntesis de cierre, sigo parseando argumentos
+                while (
+                    not self._is_at_end()
+                    and self._lookahead().token_type != TokenType.RIGHT_PAREN
+                ):
+                    # Consumo el primer argumento
                     arguments.append(self.expression())
 
-            # Si o sí tengo que cerrar el paréntesis abierto
-            if not self._match(TokenType.RIGHT_PAREN):
-                raise SyntaxError(
-                    f"Expected ')' after function arguments, got `{self._lookahead()}` instead"
-                )
+                    # Consumo un argumento por cada coma que tengo adelante
+                    while not self._is_at_end() and self._match(TokenType.COMMA):
+                        arguments.append(self.expression())
 
-            expr = CallExpr(expr, arguments)
+                # Si o sí tengo que cerrar el paréntesis abierto
+                if not self._match(TokenType.RIGHT_PAREN):
+                    raise SyntaxError(
+                        f"Expected ')' after function arguments, got `{self._lookahead()}` instead"
+                    )
+
+                expr = CallExpr(expr, arguments)
+
+            elif self._match(TokenType.LEFT_BRACKET):
+                # Consumo el índice
+                index = self.expression()
+
+                # Si o sí tengo que cerrar el corchete abierto
+                if not self._match(TokenType.RIGHT_BRACKET):
+                    raise SyntaxError(
+                        f"Expected ']' after index expression, got `{self._lookahead()}` instead"
+                    )
+
+                expr = IndexExpr(expr, index)
+
+            else:
+                break
 
         return expr
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -548,9 +548,12 @@ class Parser(object):
     def call(self) -> Expr:
         expr = self.primary()
 
-        # Si me cruzo un paréntesis abierto, tengo una llamada a función
-        # y tengo que parsear los argumentos
-        while True:
+        while (
+            not self._is_at_end() 
+            and self._lookahead().token_type in [TokenType.LEFT_PAREN, TokenType.LEFT_BRACKET]
+        ):
+            # Si me cruzo un paréntesis abierto, tengo una llamada a función
+            # y tengo que parsear los argumentos
             if self._match(TokenType.LEFT_PAREN):
                 arguments: list[Expr] = []
 
@@ -574,6 +577,7 @@ class Parser(object):
 
                 expr = CallExpr(expr, arguments)
 
+            # Si me cruzo un corchete abierto, tengo una operación de índice
             elif self._match(TokenType.LEFT_BRACKET):
                 # Consumo el índice
                 index = self.expression()
@@ -585,9 +589,6 @@ class Parser(object):
                     )
 
                 expr = IndexExpr(expr, index)
-
-            else:
-                break
 
         return expr
 

--- a/plox/PrettyPrinter.py
+++ b/plox/PrettyPrinter.py
@@ -17,6 +17,7 @@ from .Expr import (
     AssignmentExpr,
     BinaryExpr,
     CallExpr,
+    IndexExpr,
     GroupingExpr,
     LiteralExpr,
     LogicExpr,
@@ -154,6 +155,12 @@ class PrettyPrinter:
         self._store_expr("@", "CallExpr")
         self._branch(Branch.MID, reversed(expr.arguments))
         self._branch(Branch.LAST, [expr.callee])
+
+    @_accept.register
+    def _(self, expr: IndexExpr):
+        self._store_expr("@", "IndexExpr")
+        self._branch(Branch.MID, [expr.target])
+        self._branch(Branch.LAST, [expr.index])
 
     @_accept.register
     def _(self, expr: GroupingExpr):

--- a/plox/PrettyPrinter.py
+++ b/plox/PrettyPrinter.py
@@ -158,7 +158,7 @@ class PrettyPrinter:
 
     @_accept.register
     def _(self, expr: IndexExpr):
-        self._store_expr("@", "IndexExpr")
+        self._store_expr("[]", "IndexExpr")
         self._branch(Branch.MID, [expr.target])
         self._branch(Branch.LAST, [expr.index])
 

--- a/plox/Resolver.py
+++ b/plox/Resolver.py
@@ -23,6 +23,7 @@ from .Expr import (
     AssignmentExpr,
     LogicExpr,
     CallExpr,
+    IndexExpr,
     TernaryExpr,
     PostfixExpr,
 )
@@ -226,6 +227,11 @@ class Resolver(object):
         self.resolve(expression.callee)
         for arg in expression.arguments:
             self.resolve(arg)
+
+    @resolve.register
+    def _(self, expression: IndexExpr):
+        self.resolve(expression.target)
+        self.resolve(expression.index)
 
     @resolve.register
     def _(self, expression: TernaryExpr):

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -67,6 +67,10 @@ class Scanner(object):
                 self.add_token(TokenType.LEFT_BRACE)
             case "}":
                 self.add_token(TokenType.RIGHT_BRACE)
+            case "[":
+                self.add_token(TokenType.LEFT_BRACKET)
+            case "]":
+                self.add_token(TokenType.RIGHT_BRACKET)
             case ",":
                 self.add_token(TokenType.COMMA)
             case "-":

--- a/plox/Token.py
+++ b/plox/Token.py
@@ -8,6 +8,8 @@ class TokenType(Enum):
     RIGHT_PAREN = auto()
     LEFT_BRACE = auto()
     RIGHT_BRACE = auto()
+    LEFT_BRACKET = auto()
+    RIGHT_BRACKET = auto()
     COMMA = auto()
     MINUS = auto()
     SEMICOLON = auto()

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -255,7 +255,6 @@ def test_index():
         value = Interpreter().evaluate(expr)
         assert value == expected
     
-    
     tokens = Scanner('"test"[1.5]').scan()
     expr = Parser(tokens).expression()
     with pytest.raises(RuntimeError) as excinfo:
@@ -283,3 +282,38 @@ def test_index():
         Interpreter().evaluate(expr)
 
     assert "Index out of range" in str(excinfo.value)
+
+def test_len_function():
+    tests = [
+        ('len("")', 0),
+        ('len("hola")', 4),
+        ('len("con espacios")', 12)
+    ]
+
+    for src, expected in tests:
+        tokens = Scanner(src).scan()
+        expr = Parser(tokens).expression()
+        value = Interpreter().evaluate(expr)
+        assert value == expected
+    
+    tokens = Scanner('len(1)').scan()
+    expr = Parser(tokens).expression()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().evaluate(expr)
+
+    assert "Argument of `len` must be a string" in str(excinfo.value)
+
+    tokens = Scanner('len(true)').scan()
+    expr = Parser(tokens).expression()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().evaluate(expr)
+
+    assert "Argument of `len` must be a string" in str(excinfo.value)
+
+    tokens = Scanner('len(nil)').scan()
+    expr = Parser(tokens).expression()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().evaluate(expr)
+
+    assert "Argument of `len` must be a string" in str(excinfo.value)
+

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -241,6 +241,7 @@ def test_type_function_with_casting():
 def test_index():
     tests = [
         ('"string"[0]', "s"),
+        ('"string"[5]', "g"),
         ('"plox"[2]', "o"),
         ('"plox"[2.00]', "o"),
         ('"plox"[1.5 - (1.5 % 1)]', "l"),
@@ -260,14 +261,21 @@ def test_index():
     with pytest.raises(RuntimeError) as excinfo:
         Interpreter().evaluate(expr)
 
-    assert "Index must be a round number" in str(excinfo.value)
+    assert "Index must be a positive whole number" in str(excinfo.value)
 
     tokens = Scanner('"test"["error"]').scan()
     expr = Parser(tokens).expression()
     with pytest.raises(RuntimeError) as excinfo:
         Interpreter().evaluate(expr)
 
-    assert "Index must be a round number" in str(excinfo.value)
+    assert "Index must be a positive whole number" in str(excinfo.value)
+
+    tokens = Scanner('"test"[-1]').scan()
+    expr = Parser(tokens).expression()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().evaluate(expr)
+
+    assert "Index must be a positive whole number" in str(excinfo.value)
 
     tokens = Scanner('"test"[12]').scan()
     expr = Parser(tokens).expression()

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -260,4 +260,18 @@ def test_index():
     with pytest.raises(RuntimeError) as excinfo:
         Interpreter().evaluate(expr)
 
-    assert "Cannot use a non-round number as index" in str(excinfo.value)
+    assert "Index must be a round number" in str(excinfo.value)
+
+    tokens = Scanner('"test"["error"]').scan()
+    expr = Parser(tokens).expression()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().evaluate(expr)
+
+    assert "Index must be a round number" in str(excinfo.value)
+
+    tokens = Scanner('"test"[12]').scan()
+    expr = Parser(tokens).expression()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().evaluate(expr)
+
+    assert "Index out of range" in str(excinfo.value)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -149,6 +149,21 @@ def test_ternary():
         assert value == expected
 
 
+def test_index():
+    tests = [
+        ('"string"[0]', "s"),
+        ('"plox"[2]', "o"),
+        ('"plox"[2][0]', "o"),
+        ('"test"[0] + "test"[1]', "te"),
+    ]
+
+    for src, expected in tests:
+        tokens = Scanner(src).scan()
+        expr = Parser(tokens).expression()
+        value = Interpreter().evaluate(expr)
+        assert value == expected
+
+
 def test_casting():
     tests = [
         # number casting
@@ -184,7 +199,6 @@ def test_casting():
         expr = Parser(tokens).expression()
         value = Interpreter().evaluate(expr)
         assert value == expected
-
 
 def test_casting_errors():
     # Casting string no numérico a number

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -149,21 +149,6 @@ def test_ternary():
         assert value == expected
 
 
-def test_index():
-    tests = [
-        ('"string"[0]', "s"),
-        ('"plox"[2]', "o"),
-        ('"plox"[2][0]', "o"),
-        ('"test"[0] + "test"[1]', "te"),
-    ]
-
-    for src, expected in tests:
-        tokens = Scanner(src).scan()
-        expr = Parser(tokens).expression()
-        value = Interpreter().evaluate(expr)
-        assert value == expected
-
-
 def test_casting():
     tests = [
         # number casting
@@ -251,3 +236,28 @@ def test_type_function_with_casting():
         expr = Parser(tokens).expression()
         value = Interpreter().evaluate(expr)
         assert value == expected, f"type({src}) returned {value}, expected {expected}"
+
+
+def test_index():
+    tests = [
+        ('"string"[0]', "s"),
+        ('"plox"[2]', "o"),
+        ('"plox"[2.00]', "o"),
+        ('"plox"[1.5 - (1.5 % 1)]', "l"),
+        ('"plox"[2][0]', "o"),
+        ('"test"[0] + "test"[1]', "te"),
+    ]
+
+    for src, expected in tests:
+        tokens = Scanner(src).scan()
+        expr = Parser(tokens).expression()
+        value = Interpreter().evaluate(expr)
+        assert value == expected
+    
+    
+    tokens = Scanner('"test"[1.5]').scan()
+    expr = Parser(tokens).expression()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().evaluate(expr)
+
+    assert "Cannot use a non-round number as index" in str(excinfo.value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,6 +7,8 @@ from plox.Expr import (
     AssignmentExpr,
     PostfixExpr,
     TernaryExpr,
+    IndexExpr,
+    CallExpr,
 )
 from plox.Scanner import Scanner
 from plox.Parser import Parser
@@ -470,3 +472,27 @@ def test_power():
     assert expr.right.left.value == 3.0
     assert isinstance(expr.right.right, LiteralExpr)
     assert expr.right.right.value == 4.0
+
+def test_index():
+    tokens = Scanner("\"hola\"[3]").scan()
+    expr = Parser(tokens).expression()
+    assert isinstance(expr, IndexExpr)
+
+    assert isinstance(expr.target, LiteralExpr)
+    assert expr.target.value == "hola"
+    assert isinstance(expr.index, LiteralExpr)
+    assert expr.index.value == 3.0
+
+    tokens = Scanner("obtener_string()[1 + 1]").scan()
+    expr = Parser(tokens).expression()
+    assert isinstance(expr, IndexExpr)
+    assert isinstance(expr.target, CallExpr)
+    assert isinstance(expr.index, BinaryExpr)
+
+    # Soporta encadenar llamados e indexing correctamente
+    tokens = Scanner("funciones()[3]()").scan()
+    expr = Parser(tokens).expression()
+    assert isinstance(expr, CallExpr)
+    assert isinstance(expr.callee, IndexExpr)
+    assert isinstance(expr.callee.target, CallExpr)
+

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -230,7 +230,7 @@ def test_remove_multiline_comments():
 
 
 def test_single_char_tokens():
-    tokens = Scanner("(){},-+;*/%:?**").scan()
+    tokens = Scanner("(){}[],-+;*/%:?**").scan()
     tokens_type = [token.token_type for token in tokens]
 
     expected_tokens_type = [
@@ -238,6 +238,8 @@ def test_single_char_tokens():
         TokenType.RIGHT_PAREN,
         TokenType.LEFT_BRACE,
         TokenType.RIGHT_BRACE,
+        TokenType.LEFT_BRACKET,
+        TokenType.RIGHT_BRACKET,
         TokenType.COMMA,
         TokenType.MINUS,
         TokenType.PLUS,


### PR DESCRIPTION
# Agregado de string indexing

Se agrega soporte para indexar strings a plox (`"hola"[1]`). En `examples/string_indexing.lox` pueden verse distintos ejemplos de uso. Ref: #33 

## Cambios realizados
### Tokens
Se agregan los tokens de un solo caracter:
- `LEFT_BRACKET` (`[`)
- `RIGHT_BRACKET` (`]`)

### Scanner
Se agrega el escaneo de los nuevos tokens
Como en los casos de paréntesis y llaves, no se agregan revisiones sobre si están o no balanceados, esto se delega al parser.

### Expresion

Se agrega una nueva expresión `IndexExpr`. La misma cuenta con un `target` (elemento a indexar) y un `index` (indice al que se quiere acceder). La misma debería seguir siendo útil si se agregan mas tipos indexables (ejemplo: arrays).

### Parser

Se extiende la regla de call, para que soporte index. De esta forma tiene la misma precedencia que una llamada y pueden encadenarse entre si.
` call           → primary ( ("(" arguments? ")")  | "[" expression "]")* ;`

Ahora la regla de call parsea (asociando a izquierda) expresiones de call y index mientras encuentre `(` o `[`.

### Resolver
Se agrega la resolución de la nueva expresión. Para esto se resuelve tanto el `target` como el `index` ya que ambos son expresiones.

### Interpreter

Se agrega soporte para la nueva expresión `IndexExpr`.

Se evalúa primero el `target` y se verifica que sea un string. Se evalúa luego el `index` y se verifica que sea un entero positivo, y no esté fuera de rango.

Como en plox solo existe el tipo número (representado como un float), la verificación se basa en ver que no tenga parte fraccionaria (otra opción hubiera sido redondear al entero más cercano, pero podría llevar a confusiones en el uso), esto no es un problema ya que se cuenta con el operador módulo, por lo que el usuario puede redondear un número como `numero - numero % 1`.

Creo que la mayor limitación de esta nueva expresión es que actualmente no hay forma de saber que largo tiene un string (ni de manejar en todo caso el error de fuera de indice). Puede ser útil agregar una función nativa `len`, permitiendo iterar fácilmente un string.
