### PR TITLE
Variables inmutables

### DIFF
--- a/examples/const.lox
+++ b/examples/const.lox
@@ -45,3 +45,7 @@ NUM++;
 
 // Error al no inicializar
 const X;
+
+// Error al redeclarar una variable constante
+const y = 1;
+var y = 2;

--- a/examples/const.lox
+++ b/examples/const.lox
@@ -1,0 +1,47 @@
+// Correr con --line-by-line
+
+// Declaración y lectura básica
+const TRES = 3;
+print TRES; // 3
+
+var nombre = "Pepe";
+const MENSAJE = "Soy " + nombre;
+print MENSAJE; // Soy Pepe
+
+
+// Shadowing. La variable externa sigue siendo asignable después 
+// de que la const interna sale de scope
+var X = 0;
+{
+    const X = 50;
+    print X; // 50
+}
+X = X + 1;
+print X; // 1
+
+// Utilizamos variable constante dentro de un bucle while
+var i = 1;
+while (i <= 3) {
+    const VALOR = i * 10;
+    print VALOR; // 10, 20, 30
+    i++;
+}
+
+// Utilizamos variable constante dentro de una función
+fun suma_10(n) {
+    const DIEZ = 10;
+    return DIEZ + n;
+}
+print suma_10(5); // 15
+print suma_10(42); // 52
+
+// Error al reasignar una variable constante
+const NUM = 1;
+NUM = 0;
+
+// Error al usar postfix en una variable constante
+const NUM = 5;
+NUM++;
+
+// Error al no inicializar
+const X;

--- a/plox/Env.py
+++ b/plox/Env.py
@@ -30,12 +30,12 @@ class Env(object):
             env = env.enclosing
         return env
 
-    def define(self, name: str, value: object, is_const: bool = False):
+    def define(self, name: str, value: object, is_constant: bool = False):
         # No estamos chequeando si la variable ya esta definida.
         # Lox nos permite hacer var x = 1; var x = 2;
         # mientras que otros lenguajes lo consideran un error
         self.values[name] = value
-        if is_const:
+        if is_constant:
             self.consts.add(name)
 
     def get(self, name: str, distance: int | None = None) -> object:

--- a/plox/Env.py
+++ b/plox/Env.py
@@ -4,6 +4,8 @@ from typing import Optional
 class Env(object):
     def __init__(self, *, enclosing: Optional["Env"] = None):
         self.values: dict[str, object] = {}
+        # Guarda las variables que son constantes
+        self.consts: set[str] = set()
         # El entorno global es el único que no tiene enclosing
         self.enclosing: Optional["Env"] = enclosing
 
@@ -28,11 +30,13 @@ class Env(object):
             env = env.enclosing
         return env
 
-    def define(self, name: str, value: object):
+    def define(self, name: str, value: object, is_const: bool = False):
         # No estamos chequeando si la variable ya esta definida.
         # Lox nos permite hacer var x = 1; var x = 2;
         # mientras que otros lenguajes lo consideran un error
         self.values[name] = value
+        if is_const:
+            self.consts.add(name)
 
     def get(self, name: str, distance: int | None = None) -> object:
         scope = self
@@ -58,6 +62,8 @@ class Env(object):
             scope = self.ancestor(distance)
 
         if name in scope.values:
+            if name in scope.consts:
+                raise RuntimeError(f"Cannot assign to constant '{name}'")
             scope.values[name] = value
             return value
 

--- a/plox/Env.py
+++ b/plox/Env.py
@@ -34,6 +34,9 @@ class Env(object):
         # No estamos chequeando si la variable ya esta definida.
         # Lox nos permite hacer var x = 1; var x = 2;
         # mientras que otros lenguajes lo consideran un error
+        # Sin embargo, no se puede re-declarar una variable constante.
+        if name in self.consts:
+            raise RuntimeError(f"Cannot re-declare constant '{name}'")
         self.values[name] = value
         if is_constant:
             self.consts.add(name)

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -88,7 +88,7 @@ class Interpreter(object):
     def _(self, statement: VarDecl):
         # Ejecutar una declaración de una variable es solamente agregar el binding al entorno
         if statement.initializer is not None:
-            self.env.define(statement.name.lexeme, self.evaluate(statement.initializer))
+            self.env.define(statement.name.lexeme, self.evaluate(statement.initializer), statement.is_const)
         else:
             self.env.define(statement.name.lexeme, statement.initializer)
 

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -88,7 +88,7 @@ class Interpreter(object):
     def _(self, statement: VarDecl):
         # Ejecutar una declaración de una variable es solamente agregar el binding al entorno
         if statement.initializer is not None:
-            self.env.define(statement.name.lexeme, self.evaluate(statement.initializer), statement.is_const)
+            self.env.define(statement.name.lexeme, self.evaluate(statement.initializer), statement.is_constant)
         else:
             self.env.define(statement.name.lexeme, statement.initializer)
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -49,7 +49,7 @@ class Parser(object):
         
         # si me cruzo un const, parseo una variable declaration
         if self._match(TokenType.CONST):
-            return self.variable_declaration(is_const=True)
+            return self.variable_declaration(is_constant=True)
 
         # si me cruzo un fun, parseo una function declaration
         if self._match(TokenType.FUN):
@@ -308,7 +308,7 @@ class Parser(object):
         return FunDecl(functionname, parameters, body)
 
     # varDecl        → ( "var" | "const" ) IDENTIFIER ( "=" expression )? ";" ;
-    def variable_declaration(self, is_const: bool = False) -> VarDecl:
+    def variable_declaration(self, is_constant: bool = False) -> VarDecl:
         if not self._match(TokenType.IDENTIFIER):
             raise SyntaxError(
                 f"Expected variable declaration, got `{self._lookahead()}` instead"
@@ -317,7 +317,7 @@ class Parser(object):
         variablename = self._previous()
 
         # Const deben inicializarse sí o sí. `const x;` no es válido
-        if is_const:
+        if is_constant:
             if not self._match(TokenType.EQUAL):
                 raise SyntaxError(
                     f"Constant `{variablename.lexeme}` must be initialized at declaration"
@@ -335,7 +335,7 @@ class Parser(object):
                 f"Expected ';' after variable declaration, got `{self._lookahead()}` instead"
             )
 
-        return VarDecl(variablename, variablevalue, is_const)
+        return VarDecl(variablename, variablevalue, is_constant)
 
     # ---------- Reglas de Producción de Expresiones ---------- #
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -46,6 +46,10 @@ class Parser(object):
         # si me cruzo un var, parseo una variable declaration
         if self._match(TokenType.VAR):
             return self.variable_declaration()
+        
+        # si me cruzo un const, parseo una variable declaration
+        if self._match(TokenType.CONST):
+            return self.variable_declaration(is_const=True)
 
         # si me cruzo un fun, parseo una function declaration
         if self._match(TokenType.FUN):
@@ -303,8 +307,8 @@ class Parser(object):
         body = self.block()
         return FunDecl(functionname, parameters, body)
 
-    # varDecl        → "var" IDENTIFIER ( "=" expression )? ";" ;
-    def variable_declaration(self) -> VarDecl:
+    # varDecl        → ( "var" | "const" ) IDENTIFIER ( "=" expression )? ";" ;
+    def variable_declaration(self, is_const: bool = False) -> VarDecl:
         if not self._match(TokenType.IDENTIFIER):
             raise SyntaxError(
                 f"Expected variable declaration, got `{self._lookahead()}` instead"
@@ -312,8 +316,15 @@ class Parser(object):
 
         variablename = self._previous()
 
+        # Const deben inicializarse sí o sí. `const x;` no es válido
+        if is_const:
+            if not self._match(TokenType.EQUAL):
+                raise SyntaxError(
+                    f"Constant `{variablename.lexeme}` must be initialized at declaration"
+                ) 
+            variablevalue = self.expression() # const x = valor;
         # Si no se especifica un valor para la variable, se le asigna Nil
-        if self._match(TokenType.EQUAL):  # var x = valor;
+        elif self._match(TokenType.EQUAL):  # var x = valor;
             variablevalue = self.expression()
         else:  # var x;
             variablevalue = None
@@ -324,7 +335,7 @@ class Parser(object):
                 f"Expected ';' after variable declaration, got `{self._lookahead()}` instead"
             )
 
-        return VarDecl(variablename, variablevalue)
+        return VarDecl(variablename, variablevalue, is_const)
 
     # ---------- Reglas de Producción de Expresiones ---------- #
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -317,14 +317,13 @@ class Parser(object):
         variablename = self._previous()
 
         # Const deben inicializarse sí o sí. `const x;` no es válido
-        if is_constant:
-            if not self._match(TokenType.EQUAL):
-                raise SyntaxError(
-                    f"Constant `{variablename.lexeme}` must be initialized at declaration"
-                ) 
-            variablevalue = self.expression() # const x = valor;
-        # Si no se especifica un valor para la variable, se le asigna Nil
-        elif self._match(TokenType.EQUAL):  # var x = valor;
+        if is_constant and self._lookahead().token_type != TokenType.EQUAL:
+            raise SyntaxError(
+                f"Constant `{variablename.lexeme}` must be initialized at declaration"
+            )
+            
+        # Si no se especifica un valor para la variable mutable (var), se le asigna Nil
+        if self._match(TokenType.EQUAL):  # var x = valor; o const x = valor;
             variablevalue = self.expression()
         else:  # var x;
             variablevalue = None

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -322,7 +322,7 @@ class Parser(object):
                 f"Constant `{variablename.lexeme}` must be initialized at declaration"
             )
             
-        # Si no se especifica un valor para la variable mutable (var), se le asigna Nil
+        # Si no se especifica un valor para la variable, se le asigna Nil
         if self._match(TokenType.EQUAL):  # var x = valor; o const x = valor;
             variablevalue = self.expression()
         else:  # var x;

--- a/plox/Resolver.py
+++ b/plox/Resolver.py
@@ -30,11 +30,11 @@ from .Expr import (
 
 
 class VarInformation:
-    def __init__(self, defined: bool, used: bool):
-        # Guardamos si la variable fue definida y si fue usada
+    def __init__(self, defined: bool, used: bool, is_const: bool = False):
+        # Guardamos si la variable fue definida, si fue usada y si es constante
         self.defined = defined
         self.used = used
-
+        self.is_const = is_const
 
 class Resolver(object):
     def __init__(self, interpreter: Interpreter):
@@ -65,7 +65,7 @@ class Resolver(object):
                 warning = f'[warning] Variable "{name}" is never used.'
                 self.warnings.append(warning)
 
-    def declare(self, name: str):
+    def declare(self, name: str, is_const: bool = False):
         # Declarar una variable es guardarla con defined=False en el tope del stack
         if not self.scopes:
             return
@@ -73,13 +73,13 @@ class Resolver(object):
         if name in self.scopes[-1]:
             raise NameError(f"Variable `{name}` already exists")
 
-        self.scopes[-1][name] = VarInformation(defined=False, used=False)
+        self.scopes[-1][name] = VarInformation(defined=False, used=False, is_const=is_const)
 
     def define(self, name: str):
-        # Definir una variable es guardarla con defined=True en el tope del stack
+        # Definir una variable es guardarla con defined=True, preservando el resto de la info
         if not self.scopes:
             return
-        self.scopes[-1][name] = VarInformation(defined=True, used=False)
+        self.scopes[-1][name].defined = True
 
     def mark_used(self, var_info: VarInformation):
         # Marca una variable como usada (le agrega la informacion a VarInformation)
@@ -106,7 +106,7 @@ class Resolver(object):
         # Esto esta desacoplado de esta manera para que podamos atajar
         # el error donde uno hace `var x = x;`, e intenta
         # referenciar una variable que todavía no fue definida
-        self.declare(statement.name.lexeme)
+        self.declare(statement.name.lexeme, statement.is_const)
         if statement.initializer is not None:
             self.resolve(statement.initializer)
         self.define(statement.name.lexeme)
@@ -187,6 +187,10 @@ class Resolver(object):
         # se tiene que asignar el valor de la variable
         for i, scope in enumerate(reversed(self.scopes)):
             if expression.name.lexeme in scope:
+                if scope[expression.name.lexeme].is_const:
+                    raise NameError(
+                        f"Cannot assign to constant '{expression.name.lexeme}'"
+                    )
                 self.interpreter.resolve_depth(expression, i)
                 return value
 

--- a/plox/Resolver.py
+++ b/plox/Resolver.py
@@ -30,11 +30,11 @@ from .Expr import (
 
 
 class VarInformation:
-    def __init__(self, defined: bool, used: bool, is_const: bool = False):
+    def __init__(self, defined: bool, used: bool, is_constant: bool = False):
         # Guardamos si la variable fue definida, si fue usada y si es constante
         self.defined = defined
         self.used = used
-        self.is_const = is_const
+        self.is_constant = is_constant
 
 class Resolver(object):
     def __init__(self, interpreter: Interpreter):
@@ -65,7 +65,7 @@ class Resolver(object):
                 warning = f'[warning] Variable "{name}" is never used.'
                 self.warnings.append(warning)
 
-    def declare(self, name: str, is_const: bool = False):
+    def declare(self, name: str, is_constant: bool = False):
         # Declarar una variable es guardarla con defined=False en el tope del stack
         if not self.scopes:
             return
@@ -73,7 +73,7 @@ class Resolver(object):
         if name in self.scopes[-1]:
             raise NameError(f"Variable `{name}` already exists")
 
-        self.scopes[-1][name] = VarInformation(defined=False, used=False, is_const=is_const)
+        self.scopes[-1][name] = VarInformation(defined=False, used=False, is_constant=is_constant)
 
     def define(self, name: str):
         # Definir una variable es guardarla con defined=True, preservando el resto de la info
@@ -106,7 +106,7 @@ class Resolver(object):
         # Esto esta desacoplado de esta manera para que podamos atajar
         # el error donde uno hace `var x = x;`, e intenta
         # referenciar una variable que todavía no fue definida
-        self.declare(statement.name.lexeme, statement.is_const)
+        self.declare(statement.name.lexeme, statement.is_constant)
         if statement.initializer is not None:
             self.resolve(statement.initializer)
         self.define(statement.name.lexeme)
@@ -187,7 +187,7 @@ class Resolver(object):
         # se tiene que asignar el valor de la variable
         for i, scope in enumerate(reversed(self.scopes)):
             if expression.name.lexeme in scope:
-                if scope[expression.name.lexeme].is_const:
+                if scope[expression.name.lexeme].is_constant:
                     raise NameError(
                         f"Cannot assign to constant '{expression.name.lexeme}'"
                     )

--- a/plox/Stmt.py
+++ b/plox/Stmt.py
@@ -35,13 +35,13 @@ class BlockStmt(Stmt):
 
 # varDecl        → ("var" | "const") IDENTIFIER ( "=" expression )? ";" ;
 class VarDecl(Stmt):
-    def __init__(self, name: Token, initializer: Expr | None, is_const: bool = False):
+    def __init__(self, name: Token, initializer: Expr | None, is_constant: bool = False):
         self.name = name
         self.initializer = initializer
-        self.is_const = is_const
+        self.is_constant = is_constant
 
     def __repr__(self) -> str:
-        keyword = "CONST" if self.is_const else "VAR"
+        keyword = "CONST" if self.is_constant else "VAR"
         return f"{keyword} {self.name.lexeme} = {self.initializer}"
 
 

--- a/plox/Stmt.py
+++ b/plox/Stmt.py
@@ -33,14 +33,16 @@ class BlockStmt(Stmt):
         return f"{{ {'; '.join(str(stmt) for stmt in self.statements)} }}"
 
 
-# varDecl        → "var" IDENTIFIER ( "=" expression )? ";" ;
+# varDecl        → ("var" | "const") IDENTIFIER ( "=" expression )? ";" ;
 class VarDecl(Stmt):
-    def __init__(self, name: Token, initializer: Expr | None):
+    def __init__(self, name: Token, initializer: Expr | None, is_const: bool = False):
         self.name = name
         self.initializer = initializer
+        self.is_const = is_const
 
     def __repr__(self) -> str:
-        return f"VAR {self.name.lexeme} = {self.initializer}"
+        keyword = "CONST" if self.is_const else "VAR"
+        return f"{keyword} {self.name.lexeme} = {self.initializer}"
 
 
 # funDecl        → "fun" IDENTIFIER "(" parameters? ")" blockStmt ;

--- a/plox/Token.py
+++ b/plox/Token.py
@@ -55,6 +55,7 @@ class TokenType(Enum):
     TRUE = auto()
     VAR = auto()
     WHILE = auto()
+    CONST = auto()
 
     # type casting tokens
     BOOL_CAST = auto()
@@ -111,4 +112,5 @@ TokenKeywords = {
     "bool": TokenType.BOOL_CAST,
     "number": TokenType.NUMBER_CAST,
     "string": TokenType.STRING_CAST,
+    "const": TokenType.CONST,
 }

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -317,3 +317,27 @@ def test_len_function():
 
     assert "Argument of `len` must be a string" in str(excinfo.value)
 
+def test_const():
+    tokens = Scanner("const x = 42;").scan()
+    stmts = Parser(tokens).parse()
+    Interpreter().interpret(stmts)
+
+    tokens = Scanner("const x = 1; x = 2;").scan()
+    stmts = Parser(tokens).parse()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().interpret(stmts)
+    assert "Cannot assign to constant 'x'" in str(excinfo.value)
+
+    tokens = Scanner("const x = 1; x++;").scan()
+    stmts = Parser(tokens).parse()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().interpret(stmts)
+    assert "Cannot assign to constant 'x'" in str(excinfo.value)
+
+    tokens = Scanner("var x = 1; { const x = 2; } x = 99;").scan()
+    stmts = Parser(tokens).parse()
+    Interpreter().interpret(stmts)
+
+    tokens = Scanner("var x = 1; x = 2;").scan()
+    stmts = Parser(tokens).parse()
+    Interpreter().interpret(stmts)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -341,3 +341,15 @@ def test_const():
     tokens = Scanner("var x = 1; x = 2;").scan()
     stmts = Parser(tokens).parse()
     Interpreter().interpret(stmts)
+
+    tokens = Scanner("const x = 1; var x = 2;").scan()
+    stmts = Parser(tokens).parse()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().interpret(stmts)
+    assert "Cannot re-declare constant 'x'" in str(excinfo.value)
+
+    tokens = Scanner("const x = 1; const x = 2;").scan()
+    stmts = Parser(tokens).parse()
+    with pytest.raises(RuntimeError) as excinfo:
+        Interpreter().interpret(stmts)
+    assert "Cannot re-declare constant 'x'" in str(excinfo.value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -496,3 +496,19 @@ def test_index():
     assert isinstance(expr.callee, IndexExpr)
     assert isinstance(expr.callee.target, CallExpr)
 
+def test_const_decl():
+    tokens = Scanner("const x = 5;").scan()
+    stmts = Parser(tokens).parse()
+    assert len(stmts) == 1
+    stmt = stmts[0]
+    assert isinstance(stmt, VarDecl)
+    assert stmt.is_const is True
+    assert stmt.name.lexeme == "x"
+    assert isinstance(stmt.initializer, LiteralExpr)
+    assert stmt.initializer.value == 5.0
+
+def test_const_decl_error():
+    tokens = Scanner("const x;").scan()
+    with pytest.raises(SyntaxError) as excinfo:
+        Parser(tokens).parse()
+    assert str(excinfo.value) == "Constant `x` must be initialized at declaration"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -502,7 +502,7 @@ def test_const_decl():
     assert len(stmts) == 1
     stmt = stmts[0]
     assert isinstance(stmt, VarDecl)
-    assert stmt.is_const is True
+    assert stmt.is_constant is True
     assert stmt.name.lexeme == "x"
     assert isinstance(stmt.initializer, LiteralExpr)
     assert stmt.initializer.value == 5.0

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -116,7 +116,7 @@ def test_identifiers():
 
 def test_keywords():
     tokens = Scanner(
-        "and else false fun for if nil or print return true var while"
+        "and else false fun for if nil or print return true var while const"
     ).scan()
     tokens_type = [token.token_type for token in tokens]
 
@@ -134,6 +134,7 @@ def test_keywords():
         TokenType.TRUE,
         TokenType.VAR,
         TokenType.WHILE,
+        TokenType.CONST,
         TokenType.EOF,
     ]
 


### PR DESCRIPTION
# Variables Inmutables

Se agrega soporte para declarar variables inmutables utilizando la palabra clave `const`.

## Cambios realizados

- Token: Se incorporó el token `CONST` para representar la nueva palabra reservada.
- Statement: `VarDecl` contiene la flag `is_const` para distinguir entre variables mutables e inmutables.
- Scanner: No se realizaron cambios. Las palabras reservadas se resuelven con el diccionario `TokenKeywords` (lexema, token), así que solo fue necesario agregar a ese diccionario el token `const` para que el scanner la reconozca como keyword.
- Parser: `statement()` ahora reconoce const, y se actualizó `variable_declaration()` para la detección de la constante. Este chequea que una constante este inicializada. En caso de que no ocurra, lanza un error.
- Resolver: `VarInformation` ahora almacena `is_const`. `declare()` guarda esa información y `define()` ahora solo marca la variable como definida, sin reemplazar el objeto completo, para no perder la condición de inmutabilidad. Además, en `resolve(AssignmentExpr)` se lanza NameError si se intenta reasignar una constante, para detectar el error en la fase semántica antes de ejecutar el programa.
- Env: Se agregó un set `consts` para registrar los nombres declarados como constantes en cada entorno. Eso permite que el intérprete rechace reasignaciones y preserve la inmutabilidad también en tiempo de ejecución.
- Interpreter:  Al ejecutar declaraciones y asignaciones, ahora respeta la bandera is_const y delega en Env la validación de que una constante no pueda ser reasignada.
- Ejemplos: Se agregó el archivo `const.lox` en examples para mostrar el uso de la nueva funcionalidad.
- Tests: Se agregaron casos en parser e interpreter, y se actualizó la cobertura del scanner para incluir la nueva palabra reservada.

Ejemplos:
- Line by line modo scanning
```
> const TRES = 3;
CONST
IDENTIFIER<TRES>
EQUAL
NUMBER<3.0>
SEMICOLON
EOF
```

- Line by line modo parsing
```
> const TRES = 3;
CONST TRES = <3.0>

VarDecl      TRES:
LiteralExpr      3.0
```

- Error constante sin inicializar
```
> const X;
Parsing Error: Constant X must be initialized at declaration
```

- Error reasignar valor a una constante
```
> const NUM = 1;
> NUM = 0;
Runtime Error: Cannot assign to constant 'NUM'
```

Issue: https://github.com/FdelMazo/plox/issues/18
