### PR TITLE
feature/returns globales

### DIFF
--- a/examples/return.lox
+++ b/examples/return.lox
@@ -1,0 +1,9 @@
+// run in --line-by-line mode!!
+
+// Caso feliz: return dentro de una función
+fun saludar() { return "hola"; }
+
+print saludar();
+
+// Caso de error: return global
+return "Esto no funciona";

--- a/plox/Resolver.py
+++ b/plox/Resolver.py
@@ -1,3 +1,4 @@
+from enum import Enum, auto
 from functools import singledispatchmethod
 
 from .Interpreter import Interpreter
@@ -28,6 +29,9 @@ from .Expr import (
     PostfixExpr,
 )
 
+class FunctionType(Enum):
+    NONE = auto()
+    FUNCTION = auto()
 
 class VarInformation:
     def __init__(self, defined: bool, used: bool, is_constant: bool = False):
@@ -45,6 +49,9 @@ class Resolver(object):
 
         # Nos guardamos una lista con los warnings generados
         self.warnings: list[str] = []
+
+        # Verificamos si estamos dentro de una función para detectar returns globales
+        self.current_function: FunctionType = FunctionType.NONE
 
         # Una referencia al intérprete, para poder resolver las variables
         self.interpreter = interpreter
@@ -117,6 +124,9 @@ class Resolver(object):
         # fun nombre() { <scope nuevo> }
         self.declare(statement.name.lexeme)
         self.define(statement.name.lexeme)
+
+        enclosing_function = self.current_function
+        self.current_function = FunctionType.FUNCTION
         self.begin_scope()
         for param in statement.parameters:
             self.declare(param.lexeme)
@@ -124,6 +134,7 @@ class Resolver(object):
         for stmt in statement.body:
             self.resolve(stmt)
         self.end_scope()
+        self.current_function = enclosing_function
 
     ## El resto de los statements son triviales de resolver
 
@@ -137,6 +148,8 @@ class Resolver(object):
 
     @resolve.register
     def _(self, statement: ReturnStmt):
+        if self.current_function == FunctionType.NONE:
+            raise SyntaxError("Can't return from top-level code")
         if statement.value is not None:
             self.resolve(statement.value)
 

--- a/plox/Resolver.py
+++ b/plox/Resolver.py
@@ -149,7 +149,7 @@ class Resolver(object):
     @resolve.register
     def _(self, statement: ReturnStmt):
         if self.current_function == FunctionType.NONE:
-            raise SyntaxError("Can't return from top-level code")
+            raise SyntaxError("Cannot return from top-level code")
         if statement.value is not None:
             self.resolve(statement.value)
 

--- a/plox/__main__.py
+++ b/plox/__main__.py
@@ -61,6 +61,7 @@ class Plox:
             return
 
         resolver = Resolver(self.interpreter)
+        had_resolve_error = False
         for statement in statements:
             try:
                 resolver.resolve(statement)
@@ -70,9 +71,13 @@ class Plox:
                         print(colored(warning, "yellow"))
 
             except Exception as e:
+                had_resolve_error = True
                 if self.debug:
                     traceback.print_exc()
                 print(colored(f"Resolve Error: {e}", "light_red"))
+
+        if had_resolve_error:
+            return
 
         # en modo resolve, imprimimos los scopes locales del intérprete
         if self.mode == "resolve":

--- a/plox/__main__.py
+++ b/plox/__main__.py
@@ -61,7 +61,6 @@ class Plox:
             return
 
         resolver = Resolver(self.interpreter)
-        had_resolve_error = False
         for statement in statements:
             try:
                 resolver.resolve(statement)
@@ -69,15 +68,11 @@ class Plox:
                 if self.show_warnings:
                     for warning in resolver.warnings:
                         print(colored(warning, "yellow"))
-
             except Exception as e:
-                had_resolve_error = True
                 if self.debug:
                     traceback.print_exc()
                 print(colored(f"Resolve Error: {e}", "light_red"))
-
-        if had_resolve_error:
-            return
+                return
 
         # en modo resolve, imprimimos los scopes locales del intérprete
         if self.mode == "resolve":

--- a/real-tests/script.py
+++ b/real-tests/script.py
@@ -8,7 +8,7 @@ import os
 # `python3 ./script.py "go run glox"`
 # `python3 ./script.py "npm run jslox"`
 
-LOX_BINARY = sys.argv[1].split() or ['plox']
+LOX_BINARY = sys.argv[1].split() if len(sys.argv) > 1 else ['plox']
 
 currentdir = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
# Prohibir returns globales

Un `return` fuera de una función provocaba un error en tiempo de ejecución. Ahora el resolver lo detecta estáticamente y reporta el error antes de llegar al interpreter.

Issue: https://github.com/FdelMazo/plox/issues/23


## Cambios realizados

### Resolver
- Se agrega el enum `FunctionType` con dos valores: `NONE` (representa código global) y `FUNCTION` (representa estar dentro de la declaración de una función).
- Se agrega al Resolver el campo `current_function`, inicializado en `NONE`. Este campo indica si el código que se está resolviendo pertenece al código global (nivel superior del programa) o a algún tipo de función.
Aclaración: por ahora el único tipo de función que manejamos son las funciones comunes (`FUNCTION`). El diseño sigue el patrón del [libro](https://craftinginterpreters.com/resolving-and-binding.html#resolution-errors) y está preparado para extenderse en el futuro, por ejemplo cuando se implemente POO y se agregue `INITIALIZER` para constructores de clases.
- Al resolver una declaración de función (`FunDecl`), se setea `current_function = FUNCTION` antes de procesar el cuerpo y se restaura al valor anterior al salir.
- Al resolver un `ReturnStmt`, se chequea si el `return` está en código global  (haciendo `current_function == NONE`). En ese caso, se lanza el error `"Can't return from top-level code"`.

### Main
El loop de resolución ya capturaba excepciones por statement, pero después igualmente llamaba al Interpreter. Se agrega la flag `had_resolve_error` para cortar la ejecución si algún statement falló en la fase de resolución. 

### Return.lox
Se agrega archivo return.lox en la carpeta examples.

### Error 

```lox
> return 2;
Resolve Error: Can't return from top-level code
```

## Analizando esta idea en otros lenguajes

La restricción de que `return` solo pueda utilizarse dentro de una función no es exclusiva de Lox. Otros lenguajes también realizan este chequeo antes de la ejecución, aunque la fase donde ocurre depende de la arquitectura del lenguaje y su implementación.

### Python (CPython)

En Python, un `return` fuera de una función es rechazado antes de ejecutar el programa:

<img width="641" height="129" alt="image" src="https://github.com/user-attachments/assets/be1b5e11-42bc-49cf-b96a-b041d13e8a89" />

Este comportamiento corresponde a la implementación de referencia de Python, CPython. Antes de ejecutar el código, transforma el programa fuente en una representación intermedia (AST) y luego genera bytecode que será ejecutado por la máquina virtual de Python.

Durante este proceso realiza análisis sobre la estructura del programa y verifica que ciertas instrucciones aparezcan en contextos válidos. Por ejemplo, un return necesita estar asociado al contexto de una función para tener significado.

En Lox, esta responsabilidad fue implementada explícitamente mediante el Resolver, mientras que CPython integra este tipo de validaciones dentro de sus etapas internas de compilación.


### JavaScript (motor V8)

JavaScript también rechaza un `return` en el nivel global. 

<img width="294" height="57" alt="image" src="https://github.com/user-attachments/assets/2eac6463-46ef-4b9d-bdf4-ba4adc7ff3ef" />


Tomando como referencia el motor V8, el código fuente no es ejecutado directamente. Primero atraviesa etapas de análisis y compilación internas, donde se valida que ciertas construcciones sean utilizadas en contextos válidos.
A diferencia de Lox, donde implementamos una fase explícita Resolver para realizar este análisis semántico, V8 integra estas validaciones dentro de su pipeline interno.



### C / C++
En C y C++, un `return` fuera de una función también es rechazado antes de generar el ejecutable.

```C
return 10; 
int main() { }
```
<img width="677" height="79" alt="image" src="https://github.com/user-attachments/assets/c7eaaec7-db4a-4664-bfff-bf34268028e0" />



Un compilador como GCC o Clang detecta este error durante la compilación.

Dentro de la etapa del compilador se realizan el análisis sintáctico y análisis semántico. En este último se valida que ciertas construcciones tengan sentido según el contexto del programa, como determinar si una instrucción return aparece dentro del cuerpo de una función o en el nivel global.

La diferencia con Lox es que los compiladores de C/C++ continúan luego con etapas de generación de código máquina, mientras que nuestro intérprete utiliza el `Resolver` para validar el AST antes de entregarlo al `Interpreter`.


### Java
En Java, un return fuera de un método tampoco es válido.

<img width="461" height="145" alt="image" src="https://github.com/user-attachments/assets/9ab07076-ee10-4098-b953-d41f7d486da0" />


El compilador de Java (`javac`) rechaza el programa antes de generar bytecode para la JVM.

El flujo general de compilación puede representarse como:
```
Código fuente (.java) -> Parser ->  Análisis semántico ->  Bytecode (.class) -> JVM
```

Durante el análisis semántico, `javac` verifica restricciones que dependen del contexto del programa. Por ejemplo, determina si un return aparece dentro del cuerpo de un método válido.


