### PR TITLE
feat: Agrego saltos en control de flujo (break/continue).

### DIFF
--- a/plox/Function.py
+++ b/plox/Function.py
@@ -13,6 +13,14 @@ class ReturnValue(Exception):
         self.value = value
 
 
+class BreakSignal(Exception):
+    pass
+
+
+class ContinueSignal(Exception):
+    pass
+
+
 class Function(object):
     def __init__(
         self,

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -11,6 +11,9 @@ from .Stmt import (
     IfStmt,
     WhileStmt,
     ReturnStmt,
+    BreakStmt,
+    ContinueStmt,
+    ForStmt,
 )
 from .Expr import (
     Expr,
@@ -27,7 +30,7 @@ from .Expr import (
     TernaryExpr,
     PostfixExpr,
 )
-from .Function import Function, ReturnValue
+from .Function import Function, ReturnValue, BreakSignal, ContinueSignal
 from .Token import TokenType
 from .Env import Env
 from .BuiltinFunctions import TypeFunction, LenFunction
@@ -124,7 +127,43 @@ class Interpreter(object):
     def _(self, statement: WhileStmt):
         # El while se implementa con... un while
         while self.is_truthy(self.evaluate(statement.condition)):
-            self.execute(statement.body)
+            try:
+                self.execute(statement.body)
+            except BreakSignal:
+                break
+            except ContinueSignal:
+                continue
+
+    @execute.register
+    def _(self, statement: ForStmt):
+        # El for tiene su propio nodo para que continue ejecute el incremento
+        for_env = Env(enclosing=self.env)
+        previous_env = self.env
+        self.env = for_env
+        try:
+            if statement.initializer is not None:
+                self.execute(statement.initializer)
+            condition = statement.condition
+            while condition is None or self.is_truthy(self.evaluate(condition)):
+                try:
+                    self.execute(statement.body)
+                except BreakSignal:
+                    return
+                except ContinueSignal:
+                    pass
+                # El incremento se ejecuta siempre, incluso si hubo continue
+                if statement.increment is not None:
+                    self.evaluate(statement.increment)
+        finally:
+            self.env = previous_env
+
+    @execute.register
+    def _(self, statement: BreakStmt):
+        raise BreakSignal()
+
+    @execute.register
+    def _(self, statement: ContinueStmt):
+        raise ContinueSignal()
 
     @execute.register
     def _(self, statement: BlockStmt):

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -24,6 +24,9 @@ from .Stmt import (
     IfStmt,
     WhileStmt,
     ReturnStmt,
+    BreakStmt,
+    ContinueStmt,
+    ForStmt,
 )
 
 
@@ -31,6 +34,7 @@ class Parser(object):
     def __init__(self, tokens: list[Token]):
         self.tokens = tokens  # la lista de tokens ya escaneados
         self.current = 0  # el token en el que estamos parados
+        self._loop_depth = 0  # para validar break/continue fuera de bucles
 
     # Obtiene la lista de statements parseados
     def parse(self) -> list[Stmt]:
@@ -58,6 +62,14 @@ class Parser(object):
         # si me cruzo un return, parseo un return statement
         if self._match(TokenType.RETURN):
             return self.return_statement()
+
+        # si me cruzo un break, parseo un break statement
+        if self._match(TokenType.BREAK):
+            return self.break_statement()
+
+        # si me cruzo un continue, parseo un continue statement
+        if self._match(TokenType.CONTINUE):
+            return self.continue_statement()
 
         # si me cruzo un if, parseo un if statement
         if self._match(TokenType.IF):
@@ -144,7 +156,9 @@ class Parser(object):
                 f"Expected ')' after condition, got `{self._lookahead()}` instead"
             )
 
+        self._loop_depth += 1
         body = self.statement()
+        self._loop_depth -= 1
 
         return WhileStmt(condition, body)
 
@@ -178,11 +192,8 @@ class Parser(object):
     def for_statement(self) -> Stmt:
         # El for se compone de 3 cláusulas: un inicializador, una condición y un incremento
         # Y estas 3 cláusulas son opcionales!
-
-        # En vez de agregar un statement a nuestra gramática, vamos a reutilizar lo que ya tenemos:
-        # implementamos el for como un syntactic sugar de un while.
-        # Parseamos el inicializador, la condición y el incremento, y los agrupamos en un bloque que sea
-        # { inicializador; while (condición) { cuerpo; incremento; } }
+        # Usamos un nodo ForStmt propio (en vez de desugaring a WhileStmt)
+        # para que continue pueda ejecutar el incremento correctamente.
 
         # Después de un for, espero un paréntesis abierto
         if not self._match(TokenType.LEFT_PAREN):
@@ -191,7 +202,7 @@ class Parser(object):
             )
 
         initializer: None | VarDecl | ExpressionStmt = None
-        # Si ya me cruzo un punto y coma, me saltee el inicializaodr
+        # Si ya me cruzo un punto y coma, me salteé el inicializador
         if self._match(TokenType.SEMICOLON):
             initializer = None
         elif self._match(TokenType.VAR):
@@ -219,25 +230,32 @@ class Parser(object):
                 f"Expected ')' after for loop clauses, got `{self._lookahead()}` instead"
             )
 
-        # Tomamos el cuerpo del form
+        # Tomamos el cuerpo del for
+        self._loop_depth += 1
         body = self.statement()
+        self._loop_depth -= 1
 
-        # Si tengo un incremento, lo agrego al final del cuerpo que voy a ejecutar en cada iteración
-        if increment is not None:
-            body = BlockStmt([body, ExpressionStmt(increment)])
+        return ForStmt(initializer, condition, increment, body)
 
-        # Si no tengo una condición, la reemplazo por un literal que siempre evalue a verdadero
-        if condition is None:
-            condition = LiteralExpr(True)
+    # breakStmt     → "break" ";" ;
+    def break_statement(self) -> BreakStmt:
+        if self._loop_depth == 0:
+            raise SyntaxError("Cannot use 'break' outside of a loop")
+        if not self._match(TokenType.SEMICOLON):
+            raise SyntaxError(
+                f"Expected ';' after 'break', got `{self._lookahead()}` instead"
+            )
+        return BreakStmt()
 
-        body = WhileStmt(condition, body)
-
-        # Si tengo un inicializador, entonces reemplazo los statements que tengo por un
-        # bloque que arranque por el inicializador, y después interprete el while
-        if initializer is not None:
-            body = BlockStmt([initializer, body])
-
-        return body
+    # continueStmt  → "continue" ";" ;
+    def continue_statement(self) -> ContinueStmt:
+        if self._loop_depth == 0:
+            raise SyntaxError("Cannot use 'continue' outside of a loop")
+        if not self._match(TokenType.SEMICOLON):
+            raise SyntaxError(
+                f"Expected ';' after 'continue', got `{self._lookahead()}` instead"
+            )
+        return ContinueStmt()
 
     # returnStmt     → "return" expression? ";" ;
     def return_statement(self) -> ReturnStmt:

--- a/plox/PrettyPrinter.py
+++ b/plox/PrettyPrinter.py
@@ -11,6 +11,9 @@ from .Stmt import (
     Stmt,
     VarDecl,
     WhileStmt,
+    BreakStmt,
+    ContinueStmt,
+    ForStmt,
 )
 from .Expr import (
     Expr,
@@ -135,6 +138,28 @@ class PrettyPrinter:
         self._shift([stmt.condition])
 
         self._store_stmt("body:", "WhileStmt(body)")
+        self._shift([stmt.body])
+
+    @_accept.register
+    def _(self, stmt: BreakStmt):
+        self._store_stmt("", "BreakStmt")
+
+    @_accept.register
+    def _(self, stmt: ContinueStmt):
+        self._store_stmt("", "ContinueStmt")
+
+    @_accept.register
+    def _(self, stmt: ForStmt):
+        self._store_stmt("for:", "ForStmt(init)")
+        if stmt.initializer is not None:
+            self._shift([stmt.initializer])
+        self._store_stmt("cond:", "ForStmt(cond)")
+        if stmt.condition is not None:
+            self._shift([stmt.condition])
+        self._store_stmt("incr:", "ForStmt(incr)")
+        if stmt.increment is not None:
+            self._shift([stmt.increment])
+        self._store_stmt("body:", "ForStmt(body)")
         self._shift([stmt.body])
 
     # ---------- Handlers de Expresiones ---------- #

--- a/plox/Resolver.py
+++ b/plox/Resolver.py
@@ -11,6 +11,9 @@ from .Stmt import (
     IfStmt,
     WhileStmt,
     ReturnStmt,
+    BreakStmt,
+    ContinueStmt,
+    ForStmt,
 )
 from .Expr import (
     Expr,
@@ -151,6 +154,27 @@ class Resolver(object):
     def _(self, statement: WhileStmt):
         self.resolve(statement.condition)
         self.resolve(statement.body)
+
+    @resolve.register
+    def _(self, statement: ForStmt):
+        # El for abre su propio scope para el inicializador
+        self.begin_scope()
+        if statement.initializer is not None:
+            self.resolve(statement.initializer)
+        if statement.condition is not None:
+            self.resolve(statement.condition)
+        if statement.increment is not None:
+            self.resolve(statement.increment)
+        self.resolve(statement.body)
+        self.end_scope()
+
+    @resolve.register
+    def _(self, statement: BreakStmt):
+        pass
+
+    @resolve.register
+    def _(self, statement: ContinueStmt):
+        pass
 
     # ---------- Resolver Expresiones ---------- #
 

--- a/plox/Stmt.py
+++ b/plox/Stmt.py
@@ -87,3 +87,28 @@ class WhileStmt(Stmt):
 
     def __repr__(self) -> str:
         return f"WHILE {self.condition} {self.body}"
+
+
+# breakStmt     → "break" ";" ;
+class BreakStmt(Stmt):
+    def __repr__(self) -> str:
+        return "BREAK"
+
+
+# continueStmt  → "continue" ";" ;
+class ContinueStmt(Stmt):
+    def __repr__(self) -> str:
+        return "CONTINUE"
+
+
+# forStmt  → "for" "(" (varDecl | exprStmt | ";") expr? ";" expr? ")" statement ;
+# Se mantiene como nodo propio para que continue pueda ejecutar el incremento
+class ForStmt(Stmt):
+    def __init__(self, initializer, condition, increment, body):
+        self.initializer = initializer
+        self.condition = condition
+        self.increment = increment
+        self.body = body
+
+    def __repr__(self) -> str:
+        return f"FOR ({self.initializer}; {self.condition}; {self.increment}) {self.body}"

--- a/plox/Token.py
+++ b/plox/Token.py
@@ -56,6 +56,8 @@ class TokenType(Enum):
     VAR = auto()
     WHILE = auto()
     CONST = auto()
+    BREAK = auto()
+    CONTINUE = auto()
 
     # type casting tokens
     BOOL_CAST = auto()
@@ -113,4 +115,6 @@ TokenKeywords = {
     "number": TokenType.NUMBER_CAST,
     "string": TokenType.STRING_CAST,
     "const": TokenType.CONST,
+    "break": TokenType.BREAK,
+    "continue": TokenType.CONTINUE,
 }

--- a/real-tests/1-flow.lox
+++ b/real-tests/1-flow.lox
@@ -26,33 +26,6 @@ if (match == 3) {
     print "ERROR";
 }
 
-print "--- BREAK en while ---";
-var i = 0;
-while (true) {
-    if (i == 3) break;
-    i = i + 1;
-}
-if (i == 3) {
-    print "OK";
-} else {
-    print "ERROR: break en while falló";
-}
-
-print "--- CONTINUE en while ---";
-var sum = 0;
-var i = 0;
-while (i < 5) {
-    i = i + 1;
-    if (i == 3) continue;
-    sum = sum + i;
-}
-// suma 1+2+4+5 = 12 (se saltea 3)
-if (sum == 12) {
-    print "OK";
-} else {
-    print "ERROR: continue en while falló";
-}
-
 print "--- FOR ---";
 var match = 0;
 for (var i = 0 ; i <= 5; i = i + 1) {
@@ -63,55 +36,4 @@ if (match == 5) {
     print "OK";
 } else {
     print "ERROR";
-}
-
-print "--- BREAK en for ---";
-var last = -1;
-for (var i = 0; i < 10; i = i + 1) {
-    if (i == 4) break;
-    last = i;
-}
-if (last == 3) {
-    print "OK";
-} else {
-    print "ERROR: break en for falló";
-}
-
-print "--- CONTINUE en for (incremento debe ejecutarse) ---";
-var count = 0;
-for (var i = 0; i < 5; i = i + 1) {
-    if (i == 2) continue;
-    count = count + 1;
-}
-// itera i=0,1,2,3,4 pero salta i==2, entonces count=4
-if (count == 4) {
-    print "OK";
-} else {
-    print "ERROR: continue en for falló";
-}
-
-print "--- BREAK solo rompe el loop interno ---";
-var outer = 0;
-for (var i = 0; i < 3; i = i + 1) {
-    for (var j = 0; j < 10; j = j + 1) {
-        if (j == 1) break;
-    }
-    outer = outer + 1;
-}
-if (outer == 3) {
-    print "OK";
-} else {
-    print "ERROR: break rompió loop externo";
-}
-
-print "--- FOR infinito con break ---";
-var n = 0;
-for (;;) {
-    n = n + 1;
-    if (n == 5) break;
-}
-if (n == 5) {
-    print "OK";
-} else {
-    print "ERROR: for infinito con break falló";
 }

--- a/real-tests/1-flow.lox
+++ b/real-tests/1-flow.lox
@@ -26,6 +26,33 @@ if (match == 3) {
     print "ERROR";
 }
 
+print "--- BREAK en while ---";
+var i = 0;
+while (true) {
+    if (i == 3) break;
+    i = i + 1;
+}
+if (i == 3) {
+    print "OK";
+} else {
+    print "ERROR: break en while falló";
+}
+
+print "--- CONTINUE en while ---";
+var sum = 0;
+var i = 0;
+while (i < 5) {
+    i = i + 1;
+    if (i == 3) continue;
+    sum = sum + i;
+}
+// suma 1+2+4+5 = 12 (se saltea 3)
+if (sum == 12) {
+    print "OK";
+} else {
+    print "ERROR: continue en while falló";
+}
+
 print "--- FOR ---";
 var match = 0;
 for (var i = 0 ; i <= 5; i = i + 1) {
@@ -36,4 +63,55 @@ if (match == 5) {
     print "OK";
 } else {
     print "ERROR";
+}
+
+print "--- BREAK en for ---";
+var last = -1;
+for (var i = 0; i < 10; i = i + 1) {
+    if (i == 4) break;
+    last = i;
+}
+if (last == 3) {
+    print "OK";
+} else {
+    print "ERROR: break en for falló";
+}
+
+print "--- CONTINUE en for (incremento debe ejecutarse) ---";
+var count = 0;
+for (var i = 0; i < 5; i = i + 1) {
+    if (i == 2) continue;
+    count = count + 1;
+}
+// itera i=0,1,2,3,4 pero salta i==2, entonces count=4
+if (count == 4) {
+    print "OK";
+} else {
+    print "ERROR: continue en for falló";
+}
+
+print "--- BREAK solo rompe el loop interno ---";
+var outer = 0;
+for (var i = 0; i < 3; i = i + 1) {
+    for (var j = 0; j < 10; j = j + 1) {
+        if (j == 1) break;
+    }
+    outer = outer + 1;
+}
+if (outer == 3) {
+    print "OK";
+} else {
+    print "ERROR: break rompió loop externo";
+}
+
+print "--- FOR infinito con break ---";
+var n = 0;
+for (;;) {
+    n = n + 1;
+    if (n == 5) break;
+}
+if (n == 5) {
+    print "OK";
+} else {
+    print "ERROR: for infinito con break falló";
 }

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -353,3 +353,116 @@ def test_const():
     with pytest.raises(RuntimeError) as excinfo:
         Interpreter().interpret(stmts)
     assert "Cannot re-declare constant 'x'" in str(excinfo.value)
+
+
+def _run(src: str) -> str:
+    """Helper: interpreta src y devuelve lo impreso (sin Resolver, para tests simples)."""
+    import io, sys
+    tokens = Scanner(src).scan()
+    stmts = Parser(tokens).parse()
+    interp = Interpreter()
+    buf = io.StringIO()
+    sys.stdout = buf
+    interp.interpret(stmts)
+    sys.stdout = sys.__stdout__
+    return buf.getvalue().strip()
+
+
+def _run_with_resolver(src: str) -> str:
+    """Helper: interpreta src con Resolver (necesario cuando hay variables en scope anidado)."""
+    import io, sys
+    from plox.Resolver import Resolver
+    tokens = Scanner(src).scan()
+    stmts = Parser(tokens).parse()
+    interp = Interpreter()
+    resolver = Resolver(interp)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+    buf = io.StringIO()
+    sys.stdout = buf
+    interp.interpret(stmts)
+    sys.stdout = sys.__stdout__
+    return buf.getvalue().strip()
+
+
+def test_break_in_while():
+    result = _run("var i = 0; while (true) { if (i == 3) break; print i; i = i + 1; }")
+    assert result == "0.0\n1.0\n2.0"
+
+
+def test_break_in_while_never_entered():
+    result = _run("var i = 0; while (false) { break; print i; }")
+    assert result == ""
+
+
+def test_continue_in_while():
+    result = _run("var i = 0; while (i < 5) { i = i + 1; if (i == 3) continue; print i; }")
+    assert result == "1.0\n2.0\n4.0\n5.0"
+
+
+def test_break_in_for():
+    result = _run_with_resolver(
+        "for (var i = 0; i < 5; i = i + 1) { if (i == 3) break; print i; }"
+    )
+    assert result == "0.0\n1.0\n2.0"
+
+
+def test_continue_in_for():
+    # continue en for: el incremento (i = i + 1) debe ejecutarse igual
+    result = _run_with_resolver(
+        "for (var i = 0; i < 5; i = i + 1) { if (i == 2) continue; print i; }"
+    )
+    assert result == "0.0\n1.0\n3.0\n4.0"
+
+
+def test_break_only_innermost_loop():
+    result = _run_with_resolver(
+        "for (var i = 0; i < 3; i = i + 1) {"
+        "  for (var j = 0; j < 3; j = j + 1) { if (j == 1) break; print j; }"
+        "  print i;"
+        "}"
+    )
+    assert result == "0.0\n0.0\n0.0\n1.0\n0.0\n2.0"
+
+
+def test_continue_only_innermost_loop():
+    result = _run_with_resolver(
+        "for (var i = 0; i < 2; i = i + 1) {"
+        "  for (var j = 0; j < 3; j = j + 1) { if (j == 1) continue; print j; }"
+        "  print i;"
+        "}"
+    )
+    assert result == "0.0\n2.0\n0.0\n0.0\n2.0\n1.0"
+
+
+def test_break_outside_loop_raises():
+    with pytest.raises(SyntaxError) as excinfo:
+        Parser(Scanner("break;").scan()).parse()
+    assert "outside of a loop" in str(excinfo.value)
+
+
+def test_continue_outside_loop_raises():
+    with pytest.raises(SyntaxError) as excinfo:
+        Parser(Scanner("continue;").scan()).parse()
+    assert "outside of a loop" in str(excinfo.value)
+
+
+def test_break_outside_loop_inside_function_raises():
+    with pytest.raises(SyntaxError) as excinfo:
+        Parser(Scanner("fun f() { break; }").scan()).parse()
+    assert "outside of a loop" in str(excinfo.value)
+
+
+def test_continue_outside_loop_inside_function_raises():
+    with pytest.raises(SyntaxError) as excinfo:
+        Parser(Scanner("fun f() { continue; }").scan()).parse()
+    assert "outside of a loop" in str(excinfo.value)
+
+
+def test_break_for_infinite_loop():
+    result = _run_with_resolver(
+        "var count = 0;"
+        "for (;;) { if (count == 3) break; count = count + 1; }"
+        "print count;"
+    )
+    assert result == "3.0"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -355,22 +355,16 @@ def test_const():
     assert "Cannot re-declare constant 'x'" in str(excinfo.value)
 
 
-def _run(src: str) -> str:
-    """Helper: interpreta src y devuelve lo impreso (sin Resolver, para tests simples)."""
-    import io, sys
+def _run(src: str, capsys) -> str:
+    """Helper: interpreta src y devuelve lo impreso."""
     tokens = Scanner(src).scan()
     stmts = Parser(tokens).parse()
-    interp = Interpreter()
-    buf = io.StringIO()
-    sys.stdout = buf
-    interp.interpret(stmts)
-    sys.stdout = sys.__stdout__
-    return buf.getvalue().strip()
+    Interpreter().interpret(stmts)
+    return capsys.readouterr().out
 
 
-def _run_with_resolver(src: str) -> str:
+def _run_with_resolver(src: str, capsys) -> str:
     """Helper: interpreta src con Resolver (necesario cuando hay variables en scope anidado)."""
-    import io, sys
     from plox.Resolver import Resolver
     tokens = Scanner(src).scan()
     stmts = Parser(tokens).parse()
@@ -378,61 +372,63 @@ def _run_with_resolver(src: str) -> str:
     resolver = Resolver(interp)
     for stmt in stmts:
         resolver.resolve(stmt)
-    buf = io.StringIO()
-    sys.stdout = buf
     interp.interpret(stmts)
-    sys.stdout = sys.__stdout__
-    return buf.getvalue().strip()
+    return capsys.readouterr().out
 
 
-def test_break_in_while():
-    result = _run("var i = 0; while (true) { if (i == 3) break; print i; i = i + 1; }")
-    assert result == "0.0\n1.0\n2.0"
+def test_break_in_while(capsys):
+    result = _run("var i = 0; while (true) { if (i == 3) break; print i; i = i + 1; }", capsys)
+    assert result == "0.0\n1.0\n2.0\n"
 
 
-def test_break_in_while_never_entered():
-    result = _run("var i = 0; while (false) { break; print i; }")
+def test_break_in_while_never_entered(capsys):
+    result = _run("var i = 0; while (false) { break; print i; }", capsys)
     assert result == ""
 
 
-def test_continue_in_while():
-    result = _run("var i = 0; while (i < 5) { i = i + 1; if (i == 3) continue; print i; }")
-    assert result == "1.0\n2.0\n4.0\n5.0"
+
+def test_continue_in_while(capsys):
+    result = _run("var i = 0; while (i < 5) { i = i + 1; if (i == 3) continue; print i; }", capsys)
+    assert result == "1.0\n2.0\n4.0\n5.0\n"
 
 
-def test_break_in_for():
+def test_break_in_for(capsys):
     result = _run_with_resolver(
-        "for (var i = 0; i < 5; i = i + 1) { if (i == 3) break; print i; }"
+        "for (var i = 0; i < 5; i = i + 1) { if (i == 3) break; print i; }",
+        capsys,
     )
-    assert result == "0.0\n1.0\n2.0"
+    assert result == "0.0\n1.0\n2.0\n"
 
 
-def test_continue_in_for():
+def test_continue_in_for(capsys):
     # continue en for: el incremento (i = i + 1) debe ejecutarse igual
     result = _run_with_resolver(
-        "for (var i = 0; i < 5; i = i + 1) { if (i == 2) continue; print i; }"
+        "for (var i = 0; i < 5; i = i + 1) { if (i == 2) continue; print i; }",
+        capsys,
     )
-    assert result == "0.0\n1.0\n3.0\n4.0"
+    assert result == "0.0\n1.0\n3.0\n4.0\n"
 
 
-def test_break_only_innermost_loop():
+def test_break_only_innermost_loop(capsys):
     result = _run_with_resolver(
         "for (var i = 0; i < 3; i = i + 1) {"
         "  for (var j = 0; j < 3; j = j + 1) { if (j == 1) break; print j; }"
         "  print i;"
-        "}"
+        "}",
+        capsys,
     )
-    assert result == "0.0\n0.0\n0.0\n1.0\n0.0\n2.0"
+    assert result == "0.0\n0.0\n0.0\n1.0\n0.0\n2.0\n"
 
 
-def test_continue_only_innermost_loop():
+def test_continue_only_innermost_loop(capsys):
     result = _run_with_resolver(
         "for (var i = 0; i < 2; i = i + 1) {"
         "  for (var j = 0; j < 3; j = j + 1) { if (j == 1) continue; print j; }"
         "  print i;"
-        "}"
+        "}",
+        capsys,
     )
-    assert result == "0.0\n2.0\n0.0\n0.0\n2.0\n1.0"
+    assert result == "0.0\n2.0\n0.0\n0.0\n2.0\n1.0\n"
 
 
 def test_break_outside_loop_raises():
@@ -459,10 +455,11 @@ def test_continue_outside_loop_inside_function_raises():
     assert "outside of a loop" in str(excinfo.value)
 
 
-def test_break_for_infinite_loop():
+def test_break_for_infinite_loop(capsys):
     result = _run_with_resolver(
         "var count = 0;"
         "for (;;) { if (count == 3) break; count = count + 1; }"
-        "print count;"
+        "print count;",
+        capsys,
     )
-    assert result == "3.0"
+    assert result == "3.0\n"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -22,6 +22,7 @@ from plox.Stmt import (
     ReturnStmt,
     IfStmt,
     WhileStmt,
+    ForStmt,
 )
 from plox.Expr import VariableExpr
 
@@ -341,43 +342,42 @@ def test_for():
     assert len(stmts) == 1
     stmt = stmts[0]
 
-    assert isinstance(stmt, BlockStmt)
-    assert isinstance(stmt.statements[0], VarDecl)
-    assert stmt.statements[0].name.lexeme == "i"
-    assert isinstance(stmt.statements[1], WhileStmt)
-    ws = stmt.statements[1]
-    assert isinstance(ws.condition, BinaryExpr)
-    assert ws.condition.operator.token_type == TokenType.LESS
+    # El for ahora es un ForStmt propio (no desugareado)
+    assert isinstance(stmt, ForStmt)
+    assert isinstance(stmt.initializer, VarDecl)
+    assert stmt.initializer.name.lexeme == "i"
+    assert isinstance(stmt.condition, BinaryExpr)
+    assert stmt.condition.operator.token_type == TokenType.LESS
+    assert isinstance(stmt.increment, AssignmentExpr)
+    assert isinstance(stmt.body, BlockStmt)
+    assert isinstance(stmt.body.statements[0], PrintStmt)
 
-    assert isinstance(ws.body, BlockStmt)
-    assert isinstance(ws.body.statements[0], BlockStmt)
-    assert isinstance(ws.body.statements[0].statements[0], PrintStmt)
-    assert isinstance(ws.body.statements[1], ExpressionStmt)
-    assert isinstance(ws.body.statements[1].expression, AssignmentExpr)
-
+    # for sin inicializador: el campo initializer es None
     tokens = Scanner("for ( ; i < 3 ; i = i + 1) { print 0; }").scan()
     stmts = Parser(tokens).parse()
     assert len(stmts) == 1
-    assert isinstance(stmts[0], WhileStmt)
+    stmt = stmts[0]
+    assert isinstance(stmt, ForStmt)
+    assert stmt.initializer is None
+    assert isinstance(stmt.condition, BinaryExpr)
 
+    # for sin condición: condition es None (el intérprete lo trata como true)
     tokens = Scanner("for (var i = 0 ;  ; i = i + 1) { print 0; }").scan()
     stmts = Parser(tokens).parse()
-    assert isinstance(stmts[0], BlockStmt)
     stmt = stmts[0]
-    assert isinstance(stmt.statements[0], VarDecl)
-    assert isinstance(stmt.statements[1], WhileStmt)
-    assert isinstance(stmt.statements[1].condition, LiteralExpr)
-    assert stmt.statements[1].condition.value is True
+    assert isinstance(stmt, ForStmt)
+    assert stmt.condition is None
+    assert isinstance(stmt.initializer, VarDecl)
 
+    # for sin incremento: increment es None
     tokens = Scanner("for (var i = 0 ; i < 3 ; ) { print 0; }").scan()
     stmts = Parser(tokens).parse()
-    assert isinstance(stmts[0], BlockStmt)
     stmt = stmts[0]
-    assert isinstance(stmt.statements[1], WhileStmt)
-    inner_body = stmt.statements[1].body
-    assert isinstance(inner_body, BlockStmt)
-    assert len(inner_body.statements) == 1
-    assert isinstance(inner_body.statements[0], PrintStmt)
+    assert isinstance(stmt, ForStmt)
+    assert stmt.increment is None
+    assert isinstance(stmt.body, BlockStmt)
+    assert len(stmt.body.statements) == 1
+    assert isinstance(stmt.body.statements[0], PrintStmt)
 
 
 def test_postfix_inc():

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -116,7 +116,7 @@ def test_identifiers():
 
 def test_keywords():
     tokens = Scanner(
-        "and else false fun for if nil or print return true var while const"
+        "and else false fun for if nil or print return true var while const break continue"
     ).scan()
     tokens_type = [token.token_type for token in tokens]
 
@@ -135,6 +135,8 @@ def test_keywords():
         TokenType.VAR,
         TokenType.WHILE,
         TokenType.CONST,
+        TokenType.BREAK,
+        TokenType.CONTINUE,
         TokenType.EOF,
     ]
 


### PR DESCRIPTION
# feat: Agrego sentencias `break` y `continue`

Implementa control de flujo para bucles (issue #20).

Se agregan las sentencias `break` (salir anticipadamente de un bucle) y `continue` (saltar a la siguiente iteración) para los bucles `while` y `for`.

## Cambios

* `Token.py`: nuevos tipos de token `BREAK` y `CONTINUE`, junto con sus palabras clave.
* `Stmt.py`: nuevos nodos AST `BreakStmt` y `ContinueStmt`; también se agrega `ForStmt` (ver más abajo).
* `Function.py`: nuevas excepciones `BreakSignal` y `ContinueSignal`, siguiendo el mismo patrón utilizado por `ReturnValue`.
* `Parser.py`: análisis sintáctico de `break` y `continue`, rechazándolos fuera de bucles mediante el seguimiento de `_loop_depth` durante el parseo.
* `Interpreter.py`: `WhileStmt` captura `BreakSignal` y `ContinueSignal`; `ForStmt` cuenta con su propio manejador de ejecución.
* `Resolver.py` y `PrettyPrinter.py`: soporte para los nuevos nodos AST.
* `tests/test_scanner.py`: se agregan `break` y `continue` a `test_keywords`.
* `tests/test_parser.py`: actualización de `test_for` para soportar el nuevo `ForStmt`.
* `tests/test_interpreter.py`: se agregan 12 nuevos tests.
* `real-tests/1-flow.lox`: se agregan pruebas de integración.

## Nota sobre `ForStmt`

Originalmente, los bucles `for` se desazucaraban (*desugaring*) en el parser a:

```lox
{
  var i = 0;
  while (cond) {
    body;
    increment;
  }
}
```

siguiendo el enfoque del libro *Crafting Interpreters* (https://craftinginterpreters.com/control-flow.html#desugaring), donde se indica explícitamente que no es necesario agregar un nuevo nodo al árbol sintáctico.

Sin embargo, este desazucarado hace que `continue` se comporte incorrectamente: un `ContinueSignal` propagado desde `body` omitiría la ejecución de `increment`, lo que podría provocar bucles infinitos o una cantidad incorrecta de iteraciones.

Para resolver este problema correctamente, se introdujo `ForStmt` como un nodo AST propio. De esta forma, el intérprete puede garantizar que la expresión de incremento se ejecute siempre, incluso después de un `continue`.

Esta es una desviación deliberada respecto al enfoque del libro. Se consideró la alternativa de no soportar `continue` en bucles `for`:,pero resulta en comportamiento incompleto y poco intuitivo.

La incorporación de `ForStmt` requiere agregar manejadores en `Interpreter`, `Resolver` y `PrettyPrinter`, pero elimina la necesidad de realizar el desazucarado en `Parser`.

## `break` y `continue` en otros lenguajes

La semántica de `break` y `continue` es prácticamente universal en los lenguajes de la familia C, sin variaciones significativas entre ellos. En **C, C++, Java, JavaScript y Go** el comportamiento es idéntico al de esta implementación: `break` sale del loop inmediato, `continue` salta a la siguiente iteración ejecutando el incremento del `for` antes de reevaluar la condición.

Las variaciones aparecen en lenguajes que extienden la sintaxis básica. Java y JavaScript tienen `break LABEL` y `continue LABEL`, que permiten romper o continuar un loop externo específico en estructuras anidadas — la solución canónica al problema de salir de dos loops a la vez sin flags ni `goto` —. Rust permite que `break` devuelva un valor y soporta loops etiquetados. Ruby los llama `break` y `next`, y Python agrega un bloque `else` en los loops que se ejecuta solo si no hubo `break`.

Esta implementación se inspira directamente en **C y Java**, que es la familia en la que se basa Lox según el libro (https://craftinginterpreters.com/the-lox-language.html#hello-lox).