### PR TITLE
fix: golden rule

### DIFF
--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -1,7 +1,7 @@
 from functools import singledispatchmethod
 from typing import Any, cast
 
-from plox.Utils import golden_rule_print
+from plox.Utils import golden_rule_print, stringify
 from .Stmt import (
     Stmt,
     ExpressionStmt,
@@ -256,7 +256,7 @@ class Interpreter(object):
                 # El operador - solo funciona sobre números
                 if not self.is_number(right):
                     raise RuntimeError(
-                        f"Operand of - must be a number, got: `-{right}`"
+                        f"Operand of - must be a number, got: `-{stringify(right)}`"
                     )
                 return -right
             case TokenType.BANG:
@@ -292,6 +292,8 @@ class Interpreter(object):
         # evaluamos y chequeamos todo y luego levantamos el error.
         left = self.evaluate(expression.left)
         right = self.evaluate(expression.right)
+        left_stringified = stringify(left)
+        right_stringified = stringify(right)
 
         # Es acá donde más ojo hay que poner en qué utilizamos del lenguaje de la implementación,
         # y sobre qué agregamos lógica propia.
@@ -318,65 +320,67 @@ class Interpreter(object):
                 # Es decir, en Lox, "a" + 1 es un error. (en JavaScript, por ejemplo, sería "a1").
                 if not self.is_number(left, right) and not self.is_string(left, right):
                     raise RuntimeError(
-                        f"Operands of + must be either numbers or strings, got: `{left} + {right}`"
+                        f"Operands of + must be either numbers or strings, got: `{left_stringified} + {right_stringified}`"
                     )
                 return left + right
             case TokenType.MINUS:
                 if not self.is_number(left, right):
                     raise RuntimeError(
-                        f"Operands of - must be numbers, got: `{left} - {right}`"
+                        f"Operands of - must be numbers, got: `{left_stringified} - {right_stringified}`"
                     )
                 return left - right
             case TokenType.STAR:
                 if not self.is_number(left, right):
                     raise RuntimeError(
-                        f"Operands of * must be numbers, got: `{left} * {right}`"
+                        f"Operands of * must be numbers, got: `{left_stringified} * {right_stringified}`"
                     )
                 return left * right
             case TokenType.SLASH:
                 if not self.is_number(left, right):
                     raise RuntimeError(
-                        f"Operands of / must be numbers, got: `{left} / {right}`"
+                        f"Operands of / must be numbers, got: `{left_stringified} / {right_stringified}`"
                     )
                 elif right == 0:
-                    raise RuntimeError(f"Division by {right} is not allowed")
+                    raise RuntimeError(
+                        f"Division by {right_stringified} is not allowed"
+                    )
                 return left / right
             case TokenType.STAR_STAR:
                 if not self.is_number(left, right):
                     raise RuntimeError(
-                        f"Operands of ** must be numbers, got: `{left} ** {right}`"
+                        f"Operands of ** must be numbers, got: `{left_stringified} ** {right_stringified}`"
                     )
                 return left**right
             case TokenType.PERCENT:
                 if not self.is_number(left, right):
                     raise RuntimeError(
-                        f"Operands of % must be numbers, got: `{left} % {right}`"
+                        f"Operands of % must be numbers, got: `{left_stringified} % {right_stringified}`"
                     )
                 elif right == 0:
-                    raise RuntimeError(f"Modulo by {right} is not allowed")
+                    raise RuntimeError(f"Modulo by {right_stringified} is not allowed")
                 return left % right
             case TokenType.GREATER:
                 if not self.is_number(left, right):
                     raise RuntimeError(
-                        f"Operands of > must be numbers, got: `{left} > {right}`"
+                        f"Operands of > must be numbers, got: `{left_stringified} > {right_stringified}`"
                     )
                 return left > right
             case TokenType.GREATER_EQUAL:
                 if not self.is_number(left, right):
                     raise RuntimeError(
-                        f"Operands of >= must be numbers, got: `{left} >= {right}`"
+                        f"Operands of >= must be numbers, got: `{left_stringified} >= {right_stringified}`"
                     )
                 return left >= right
             case TokenType.LESS:
                 if not self.is_number(left, right):
                     raise RuntimeError(
-                        f"Operands of < must be numbers, got: `{left} < {right}`"
+                        f"Operands of < must be numbers, got: `{left_stringified} < {right_stringified}`"
                     )
                 return left < right
             case TokenType.LESS_EQUAL:
                 if not self.is_number(left, right):
                     raise RuntimeError(
-                        f"Operands of <= must be numbers, got: `{left} <= {right}`"
+                        f"Operands of <= must be numbers, got: `{left_stringified} <= {right_stringified}`"
                     )
                 return left <= right
             case TokenType.EQUAL_EQUAL:
@@ -418,7 +422,9 @@ class Interpreter(object):
 
         # Si el llamado no es una función, levantamos un error
         if not callable(callee):
-            raise RuntimeError(f"Cannot call non-callable object: `{callee}`")
+            raise RuntimeError(
+                f"Cannot call non-callable object: `{stringify(callee)}`"
+            )
 
         # Si no se cumple la aridad, levantamos un error
         if len(arguments) != callee.arity:
@@ -445,7 +451,7 @@ class Interpreter(object):
 
                 if not self.is_valid_dict_key(index):
                     raise RuntimeError(
-                        f"Only strings, numbers, booleans and nil can be used as dictionary keys, got: `{index}`"
+                        f"Only strings, numbers, booleans and nil can be used as dictionary keys, got: `{stringify(index)}`"
                     )
 
                 return dictionary.get(index)
@@ -457,7 +463,7 @@ class Interpreter(object):
 
             case _:
                 raise RuntimeError(
-                    f"Only arrays, dictionaries and strings support indexing, got: `{target}`"
+                    f"Only arrays, dictionaries and strings support indexing, got: `{stringify(target)}`"
                 )
 
     @evaluate.register
@@ -469,7 +475,7 @@ class Interpreter(object):
                 index = self.evaluate(expression.index)
                 if not self.is_valid_dict_key(index):
                     raise RuntimeError(
-                        f"Only strings, numbers, booleans and nil can be used as dictionary keys, got: `{index}`"
+                        f"Only strings, numbers, booleans and nil can be used as dictionary keys, got: `{stringify(index)}`"
                     )
 
                 value = self.evaluate(expression.value)
@@ -486,7 +492,7 @@ class Interpreter(object):
 
             case _:
                 raise RuntimeError(
-                    f"Only arrays, dictionaries and strings support index assignment, got: `{target}`"
+                    f"Only arrays, dictionaries and strings support index assignment, got: `{stringify(target)}`"
                 )
 
     @evaluate.register
@@ -540,7 +546,7 @@ class Interpreter(object):
             evaluated_key = self.evaluate(key)
             if not self.is_valid_dict_key(evaluated_key):
                 raise RuntimeError(
-                    f"Only strings, numbers, booleans and nil can be used as dictionary keys, got: `{evaluated_key}`"
+                    f"Only strings, numbers, booleans and nil can be used as dictionary keys, got: `{stringify(evaluated_key)}`"
                 )
 
             evaluated_value = self.evaluate(value)
@@ -577,13 +583,15 @@ class Interpreter(object):
         index_type = type(index)
         is_numeric = index_type == int or index_type == float
         if not (is_numeric and int(index) == index and index >= 0):
-            raise RuntimeError(f"Index must be a positive whole number, got: `{index}`")
+            raise RuntimeError(
+                f"Index must be a positive whole number, got: `{stringify(index)}`"
+            )
 
         index = int(index)
         # Revisamos que no esté fuera de rango
         if index >= indexable_length:
             raise RuntimeError(
-                f"Index out of range (len: {indexable_length}, index: {index})"
+                f"Index out of range (len: {stringify(indexable_length)}, index: {stringify(index)})"
             )
 
         return index
@@ -653,14 +661,18 @@ class Interpreter(object):
         nil -> "nil"
         number -> str de Python
         string -> string
+        dict -> [clave1: valor1, clave2: valor2, ...]
+        array -> [elem1, elem2, ...]
+        cualquier otro valor -> error
         """
-        if isinstance(value, bool):
-            return "true" if value else "false"
-        elif value is None:
-            return "nil"
-        elif self.is_number(value):
-            return str(float(value))
-        elif self.is_string(value):
-            return value
+        if (
+            isinstance(value, bool)
+            or value is None
+            or self.is_number(value)
+            or self.is_string(value)
+            or isinstance(value, dict)
+            or isinstance(value, list)
+        ):
+            return stringify(value)
         else:
-            raise RuntimeError(f"Cannot cast {value} to string")
+            raise RuntimeError(f"Cannot cast {stringify(value)} to string")

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -1,5 +1,7 @@
 from functools import singledispatchmethod
 from typing import Any, cast
+
+from plox.Utils import golden_rule_print
 from .Stmt import (
     Stmt,
     ExpressionStmt,
@@ -88,7 +90,7 @@ class Interpreter(object):
     def _(self, statement: PrintStmt):
         # Ejecutar un print statement es evaluar la expresión e imprimir el resultado
         value = self.evaluate(statement.expression)
-        print(value)
+        golden_rule_print(value)
 
     @execute.register
     def _(self, statement: VarDecl):

--- a/plox/Utils.py
+++ b/plox/Utils.py
@@ -2,12 +2,12 @@ from typing import Any
 
 
 def golden_rule_print(*args, **kwargs):
-    transformed_args = (_stringify(arg) for arg in args)
+    transformed_args = (stringify(arg) for arg in args)
 
     print(*transformed_args, **kwargs)  # type: ignore
 
 
-def _stringify(value: Any) -> str:
+def stringify(value: Any) -> str:
     """
     Golden rule: Convierte cualquier valor de Python a una representación de cadena que se parezca a cómo se mostraría en Lox.
     """
@@ -17,10 +17,10 @@ def _stringify(value: Any) -> str:
         case bool():
             return "true" if value else "false"
         case list():
-            return f"[{', '.join(_stringify(element) for element in value)}]"
+            return f"[{', '.join(stringify(element) for element in value)}]"
         case dict():
             items = ", ".join(
-                f"{_stringify(k)}: {_stringify(v)}" for k, v in value.items()
+                f"{stringify(k)}: {stringify(v)}" for k, v in value.items()
             )
             return f"{'[' + items + ']'}"
         case str():

--- a/plox/Utils.py
+++ b/plox/Utils.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+
+def golden_rule_print(*args, **kwargs):
+    transformed_args = (_stringify(arg) for arg in args)
+
+    print(*transformed_args, **kwargs)  # type: ignore
+
+
+def _stringify(value: Any) -> str:
+    """
+    Golden rule: Convierte cualquier valor de Python a una representación de cadena que se parezca a cómo se mostraría en Lox.
+    """
+    match value:
+        case None:
+            return "nil"
+        case bool():
+            return "true" if value else "false"
+        case list():
+            return f"[{', '.join(_stringify(element) for element in value)}]"
+        case dict():
+            items = ", ".join(
+                f"{_stringify(k)}: {_stringify(v)}" for k, v in value.items()
+            )
+            return f"{'[' + items + ']'}"
+        case str():
+            return f"'{value}'"
+        case int():
+            return f"{value}.0"
+        case _:
+            return str(value)

--- a/plox/Utils.py
+++ b/plox/Utils.py
@@ -25,7 +25,9 @@ def stringify(value: Any) -> str:
             return f"{'[' + items + ']'}"
         case str():
             return f"'{value}'"
-        case int():
-            return f"{value}.0"
+        case int() | float():
+            if isinstance(value, float) and value.is_integer():
+                return str(int(value))
+            return str(value)
         case _:
             return str(value)

--- a/plox/__main__.py
+++ b/plox/__main__.py
@@ -12,6 +12,8 @@ from termcolor import colored
 from pathlib import Path
 from platformdirs import user_data_dir
 
+from plox.Utils import golden_rule_print
+
 
 class Plox:
     def __init__(self):
@@ -88,7 +90,7 @@ class Plox:
         try:
             lastvalue_produced = self.interpreter.interpret(statements)
             if self.in_repl and lastvalue_produced is not None:
-                print(lastvalue_produced)
+                golden_rule_print(lastvalue_produced)
         except Exception as e:
             if self.debug:
                 traceback.print_exc()

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -320,15 +320,15 @@ def test_len_function():
 def test_switch(capsys):
     tokens = Scanner("switch (1) { case 1: print 'one'; case 2: print 'two'; }").scan()
     Interpreter().interpret(Parser(tokens).parse())
-    assert capsys.readouterr().out == "one\n"
+    assert capsys.readouterr().out == "'one'\n"
 
     tokens = Scanner("switch (2) { case 1: print 'one'; case 2: print 'two'; }").scan()
     Interpreter().interpret(Parser(tokens).parse())
-    assert capsys.readouterr().out == "two\n"
+    assert capsys.readouterr().out == "'two'\n"
 
     tokens = Scanner("switch ('hello') { case 'hello': print 'matched'; }").scan()
     Interpreter().interpret(Parser(tokens).parse())
-    assert capsys.readouterr().out == "matched\n"
+    assert capsys.readouterr().out == "'matched'\n"
 
     # no match and no default — no output
     tokens = Scanner("switch (99) { case 1: print 'one'; }").scan()
@@ -340,36 +340,36 @@ def test_switch(capsys):
         "switch (99) { case 1: print 'one'; default: print 'other'; }"
     ).scan()
     Interpreter().interpret(Parser(tokens).parse())
-    assert capsys.readouterr().out == "other\n"
+    assert capsys.readouterr().out == "'other'\n"
 
     # default only
     tokens = Scanner("switch (99) { default: print 'default'; }").scan()
     Interpreter().interpret(Parser(tokens).parse())
-    assert capsys.readouterr().out == "default\n"
+    assert capsys.readouterr().out == "'default'\n"
 
     # no fallthrough — only the matching case runs
     tokens = Scanner("switch (1) { case 1: print 'a'; case 1: print 'b'; }").scan()
     Interpreter().interpret(Parser(tokens).parse())
-    assert capsys.readouterr().out == "a\n"
+    assert capsys.readouterr().out == "'a'\n"
 
     # multiple statements in a case body
     tokens = Scanner("switch (1) { case 1: print 'x'; print 'y'; }").scan()
     Interpreter().interpret(Parser(tokens).parse())
-    assert capsys.readouterr().out == "x\ny\n"
+    assert capsys.readouterr().out == "'x'\n'y'\n"
 
     # subject is an expression, not just a literal
     tokens = Scanner(
         "switch (1 + 1) { case 1: print 'one'; case 2: print 'two'; }"
     ).scan()
     Interpreter().interpret(Parser(tokens).parse())
-    assert capsys.readouterr().out == "two\n"
+    assert capsys.readouterr().out == "'two'\n"
 
     # switch on a variable
     tokens = Scanner(
         "var x = 3; switch (x) { case 3: print 'three'; default: print 'other'; }"
     ).scan()
     Interpreter().interpret(Parser(tokens).parse())
-    assert capsys.readouterr().out == "three\n"
+    assert capsys.readouterr().out == "'three'\n"
 
 
 def test_const():
@@ -731,3 +731,56 @@ def test_break_for_infinite_loop(capsys):
         capsys,
     )
     assert result == "3.0\n"
+
+
+def test_golden_rule(capsys):
+    interpreter = Interpreter()
+
+    # string
+    tokens = Parser(Scanner('print "esto es un string";').scan()).parse()
+    interpreter.interpret(tokens)
+    assert capsys.readouterr().out == "'esto es un string'\n"
+
+    # int
+    tokens = Parser(Scanner("print 5;").scan()).parse()
+    interpreter.interpret(tokens)
+    out = capsys.readouterr().out
+    assert out == "5.0\n"
+    assert out != "5\n"
+
+    # float
+    tokens = Parser(Scanner("print 3.14;").scan()).parse()
+    interpreter.interpret(tokens)
+    assert capsys.readouterr().out == "3.14\n"
+
+    # array
+    tokens = Parser(Scanner("print [1, 2, 3];").scan()).parse()
+    interpreter.interpret(tokens)
+    assert capsys.readouterr().out == "[1.0, 2.0, 3.0]\n"
+
+    # nil
+    tokens = Parser(Scanner("print nil;").scan()).parse()
+    interpreter.interpret(tokens)
+    out = capsys.readouterr().out
+    assert out == "nil\n"
+    assert out != "None\n"
+
+    # bool
+    tokens = Parser(Scanner("print true;").scan()).parse()
+    interpreter.interpret(tokens)
+    out = capsys.readouterr().out
+    assert out == "true\n"
+    assert out != "True\n"
+
+    tokens = Parser(Scanner("print false;").scan()).parse()
+    interpreter.interpret(tokens)
+    out = capsys.readouterr().out
+    assert out == "false\n"
+    assert out != "False\n"
+
+    # dict
+    tokens = Parser(Scanner('print ["a": 1, "b": 2];').scan()).parse()
+    interpreter.interpret(tokens)
+    out = capsys.readouterr().out
+    assert out == "['a': 1.0, 'b': 2.0]\n"
+    assert out != "{'a': 1.0, 'b': 2.0}\n"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -169,10 +169,10 @@ def test_casting():
         ("string true", "true"),
         ("string false", "false"),
         ("string nil", "nil"),
-        ("string 42", "42.0"),
-        ("string 5.0", "5.0"),
+        ("string 42", "42"),
+        ("string 5.0", "5"),
         # nested casting
-        ('string(number "42")', "42.0"),
+        ('string(number "42")', "42"),
         ('bool(number "0")', True),
         ("bool(bool false)", False),
         ("number(string 3.19)", 3.19),
@@ -645,7 +645,7 @@ def test_break_in_while(capsys):
     result = _run(
         "var i = 0; while (true) { if (i == 3) break; print i; i = i + 1; }", capsys
     )
-    assert result == "0.0\n1.0\n2.0\n"
+    assert result == "0\n1\n2\n"
 
 
 def test_break_in_while_never_entered(capsys):
@@ -657,7 +657,7 @@ def test_continue_in_while(capsys):
     result = _run(
         "var i = 0; while (i < 5) { i = i + 1; if (i == 3) continue; print i; }", capsys
     )
-    assert result == "1.0\n2.0\n4.0\n5.0\n"
+    assert result == "1\n2\n4\n5\n"
 
 
 def test_break_in_for(capsys):
@@ -665,7 +665,7 @@ def test_break_in_for(capsys):
         "for (var i = 0; i < 5; i = i + 1) { if (i == 3) break; print i; }",
         capsys,
     )
-    assert result == "0.0\n1.0\n2.0\n"
+    assert result == "0\n1\n2\n"
 
 
 def test_continue_in_for(capsys):
@@ -674,7 +674,7 @@ def test_continue_in_for(capsys):
         "for (var i = 0; i < 5; i = i + 1) { if (i == 2) continue; print i; }",
         capsys,
     )
-    assert result == "0.0\n1.0\n3.0\n4.0\n"
+    assert result == "0\n1\n3\n4\n"
 
 
 def test_break_only_innermost_loop(capsys):
@@ -685,7 +685,7 @@ def test_break_only_innermost_loop(capsys):
         "}",
         capsys,
     )
-    assert result == "0.0\n0.0\n0.0\n1.0\n0.0\n2.0\n"
+    assert result == "0\n0\n0\n1\n0\n2\n"
 
 
 def test_continue_only_innermost_loop(capsys):
@@ -696,7 +696,7 @@ def test_continue_only_innermost_loop(capsys):
         "}",
         capsys,
     )
-    assert result == "0.0\n2.0\n0.0\n0.0\n2.0\n1.0\n"
+    assert result == "0\n2\n0\n0\n2\n1\n"
 
 
 def test_break_outside_loop_raises():
@@ -730,7 +730,7 @@ def test_break_for_infinite_loop(capsys):
         "print count;",
         capsys,
     )
-    assert result == "3.0\n"
+    assert result == "3\n"
 
 
 def test_golden_rule(capsys):
@@ -745,8 +745,7 @@ def test_golden_rule(capsys):
     tokens = Parser(Scanner("print 5;").scan()).parse()
     interpreter.interpret(tokens)
     out = capsys.readouterr().out
-    assert out == "5.0\n"
-    assert out != "5\n"
+    assert out == "5\n"
 
     # float
     tokens = Parser(Scanner("print 3.14;").scan()).parse()
@@ -756,7 +755,7 @@ def test_golden_rule(capsys):
     # array
     tokens = Parser(Scanner("print [1, 2, 3];").scan()).parse()
     interpreter.interpret(tokens)
-    assert capsys.readouterr().out == "[1.0, 2.0, 3.0]\n"
+    assert capsys.readouterr().out == "[1, 2, 3]\n"
 
     # nil
     tokens = Parser(Scanner("print nil;").scan()).parse()
@@ -782,5 +781,5 @@ def test_golden_rule(capsys):
     tokens = Parser(Scanner('print ["a": 1, "b": 2];').scan()).parse()
     interpreter.interpret(tokens)
     out = capsys.readouterr().out
-    assert out == "['a': 1.0, 'b': 2.0]\n"
-    assert out != "{'a': 1.0, 'b': 2.0}\n"
+    assert out == "['a': 1, 'b': 2]\n"
+    assert out != "{'a': 1, 'b': 2}\n"


### PR DESCRIPTION
# Golden rule 
Este PR resuelve la issue #16 buscando mostrar al usuario de lox los valores propios a lox y ocultar los del lenguaje donde realicemos la implementacion (Python, en este caso)

Para esto se agregaron dos metodos

## stringify
Este metodo convierte cualquier valor a una representacion en string en lox, guiado por la siguiente tabla

| Type (Python) | Value (Python) | Mapping (Lox) |
|--------|--------|------|
| None | None | nil |
| bool | True | true |
| bool| False | false |
| int  | 4 | 4 |
| float |3.14 | 3.14 |
| float |5.0| 5 |
| list  | [1,2,3] | [1,2,3]|
| dict | {1: 2, 3: 4}| [1: 2, 3: 4] |
| str | "hola" | 'hola' | 
|unknown| unknown| no handleado, fallback -> str(unknown) |

## golden_rule_print
Este metodo es un wrapper del print bultin de Python el cual mappea todos los args recibidos utilizando `stringify`