### PR TITLE
feat: string interpolation

### DIFF
--- a/examples/string_interpolation.lox
+++ b/examples/string_interpolation.lox
@@ -1,0 +1,28 @@
+# Interpolacion de strings
+
+# Expresiones literales
+const mundo = "Mundo";
+print "hola, ${mundo}!"; // 'hola, Mundo!'
+
+# Ternarias
+const edad = 30;
+print "${ edad >= 18 ? "Eres mayor de edad." : "Eres menor de edad." }"; // 'Eres mayor de edad.'
+
+# Binarias
+const a = 5;
+const b = 10;
+print "La suma de ${a} y ${b} es ${a + b}."; // 'La suma de 5 y 10 es 15.'
+
+# Llamadas a funciones
+fun obtenerSaludo() {
+  return "Hola";
+}
+print "${obtenerSaludo()}, ${mundo}!"; // 'Hola, Mundo!'
+
+# Interpolacion anidada
+const x = 10;
+print "${"${"${x}"}"}"; // '10'
+
+# Interpolacion anidada con expresiones
+const y = 20;
+print "${"${y + 5}"}"; // '25'

--- a/plox/Expr.py
+++ b/plox/Expr.py
@@ -44,6 +44,15 @@ class LiteralExpr(Expr):
         return str(self.value)
 
 
+class JoinedStringExpr(Expr):
+    def __init__(self, parts: list[Expr]):
+        self.parts = parts
+
+    def __repr__(self) -> str:
+        parts_str = " + ".join(str(part) for part in self.parts)
+        return f"<{parts_str}>"
+
+
 # unary          → ( "-" | "!" ) expression ;
 class UnaryExpr(Expr):
     def __init__(self, operator: Token, right: Expr):

--- a/plox/Interpreter.py
+++ b/plox/Interpreter.py
@@ -24,6 +24,7 @@ from .Expr import (
     GroupingExpr,
     IndexAssignExpr,
     ArrayExpr,
+    JoinedStringExpr,
     LiteralExpr,
     UnaryExpr,
     CastExpr,
@@ -557,6 +558,13 @@ class Interpreter(object):
     @evaluate.register
     def _(self, expression: ArrayExpr):
         return [self.evaluate(element) for element in expression.elements]
+
+    @evaluate.register
+    def _(self, expression: JoinedStringExpr):
+        return "".join(
+            stringify(self.evaluate(part), skip_quotes=True)
+            for part in expression.parts
+        )
 
     # ---------- Helpers ---------- #
 

--- a/plox/Parser.py
+++ b/plox/Parser.py
@@ -6,6 +6,7 @@ from .Expr import (
     GroupingExpr,
     IndexAssignExpr,
     ArrayExpr,
+    JoinedStringExpr,
     LiteralExpr,
     UnaryExpr,
     CastExpr,
@@ -720,8 +721,35 @@ class Parser(object):
         if self._match(TokenType.NIL):
             return LiteralExpr(None)
 
+        if self._match(TokenType.STRING):
+            string_literal = LiteralExpr(self._previous().literal)
+
+            if self._lookahead().token_type != TokenType.INTERPOLATION_START:
+                return string_literal
+
+            # En caso de interpolacion arrancamos un JoinedStringExpr
+            parts: list[Expr] = [string_literal]
+
+            while self._match(TokenType.INTERPOLATION_START):
+                parts.append(self.expression())
+
+                if not self._match(TokenType.INTERPOLATION_END):
+                    raise SyntaxError(
+                        f"Expected '}}' after interpolated expression, got `{self._lookahead()}` instead"
+                    )
+
+                # Le tiene que seguir un str aunque sea vacio
+                if not self._match(TokenType.STRING):
+                    raise SyntaxError(
+                        f"Expected string segment after interpolation, got `{self._lookahead()}` instead"
+                    )
+
+                parts.append(LiteralExpr(self._previous().literal))
+
+            return JoinedStringExpr(parts)
+
         # Si es un token literal, lo convertimos en una expresión literal con el valor del token
-        if self._match(TokenType.NUMBER, TokenType.STRING):
+        if self._match(TokenType.NUMBER):
             return LiteralExpr(self._previous().literal)
 
         # Si es un token de un identificador, lo convertimos en una expresión de una variable

--- a/plox/PrettyPrinter.py
+++ b/plox/PrettyPrinter.py
@@ -25,6 +25,7 @@ from .Expr import (
     IndexExpr,
     GroupingExpr,
     ArrayExpr,
+    JoinedStringExpr,
     LiteralExpr,
     LogicExpr,
     PostfixExpr,
@@ -243,6 +244,11 @@ class PrettyPrinter:
     @_accept.register
     def _(self, expr: ArrayExpr):
         self._store_expr("[...]", "ArrayExpr")
+
+    @_accept.register
+    def _(self, expr: JoinedStringExpr):
+        self._store_expr("joined string", "JoinedStringExpr")
+        self._branch(Branch.MID, reversed(expr.parts))
 
     # ---------- Helpers ---------- #
 

--- a/plox/Resolver.py
+++ b/plox/Resolver.py
@@ -24,6 +24,7 @@ from .Expr import (
     GroupingExpr,
     IndexAssignExpr,
     ArrayExpr,
+    JoinedStringExpr,
     LiteralExpr,
     UnaryExpr,
     CastExpr,
@@ -320,3 +321,8 @@ class Resolver(object):
     def _(self, expr: ArrayExpr):
         for element in expr.elements:
             self.resolve(element)
+
+    @resolve.register
+    def _(self, expr: JoinedStringExpr):
+        for part in expr.parts:
+            self.resolve(part)

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -252,9 +252,9 @@ class Scanner(object):
         o si no, consume el cierre del string y lo guarda como token.
         Maneja la interpolación de strings, que tiene la forma `${expresion}`.
         Si encuentra una interpolacion, se encarga de empaquetar el string para que los tokens queden ordenados
-        de la forma [ INTERPOLATION_START, STRING, ..., INTERPOLATION_END ].
+        de la forma [ STRING, INTERPOLATION_START, ..., INTERPOLATION_END, STRING ].
         Por ejemplo, para el caso "hola ${nombre}!", los tokens serían:
-        [ INTERPOLATION_START, STRING<'hola '>, IDENTIFIER<nombre>, STRING<'!'>, INTERPOLATION_END ]
+        [ STRING<'hola '>, INTERPOLATION_START, IDENTIFIER<nombre>, INTERPOLATION_END, STRING<'!'> ]
         """
         has_interpolation = False
 
@@ -262,7 +262,8 @@ class Scanner(object):
             if self._lookahead() == "$" and self._lookahead_next() == "{":
                 # Si no es la primera interpolacion, no agregamos offset al literal
                 # Esto skippeaba el char despues de '}' y algo como
-                # "${var} hola ${var2}" resultaba en [ INTERPOLATION_START, IDENTIFIER<var>, STRING<'hola ', IDENTIFIER<var2>, INTERPOLATION_END ]
+                # "${var} hola ${var2}" resultaba en
+                # [ STRING<>, INTERPOLATION_START, IDENTIFIER<var>, INTERPOLATION_END, STRING<'hola '>, ... ]
                 # Notar la falta de espacio antes de 'hola ' en STRING<'hola '>
                 start_offset = 1 if not has_interpolation else 0
                 str_literal = self.source[self.start + start_offset : self.current]

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from .Token import Token, TokenType, TokenKeywords
 
 
@@ -142,38 +144,25 @@ class Scanner(object):
 
             case "'":
                 # consumimos la cadena hasta el proximo ' o hasta el fin de linea
-                while (
-                    not self._is_at_end()
-                    and not self._lookahead() == "'"
-                    and not self._lookahead() == "\n"
-                ):
-                    self._advance()
-
-                if self._is_at_end() or self._lookahead() == "\n":
-                    # si llegamos al final de la linea, sin cerrar la cadena, es un error
-                    raise Exception(f"Unterminated string: `{self.lexeme()}`")
-
-                self._advance()  # consumimos el cierre de la cadena
-
-                # la cadena la guardamos sin las comillas
-                strvalue = self.source[self.start + 1 : self.current - 1]
-                self.add_token(TokenType.STRING, literal=strvalue)
+                self._scan_string(
+                    string_eof_criteria=lambda: (
+                        not self._is_at_end()
+                        and not self._lookahead() == "'"
+                        and not self._lookahead() == "\n"
+                    ),
+                    terminated_string_criteria=lambda: (
+                        self._is_at_end() or self._lookahead() == "\n"
+                    ),
+                )
 
             # string multilinea
             case '"':
-                # consumimos la cadena hasta el proximo "
-                while not self._is_at_end() and not self._lookahead() == '"':
-                    self._advance()
-
-                if self._is_at_end():
-                    # si llegamos al final del archivo, sin cerrar la cadena, es un error
-                    raise Exception(f"Unterminated string: `{self.lexeme()}`")
-
-                self._advance()  # consumimos el cierre de la cadena
-
-                # la cadena la guardamos sin las comillas
-                strvalue = self.source[self.start + 1 : self.current - 1]
-                self.add_token(TokenType.STRING, literal=strvalue)
+                self._scan_string(
+                    string_eof_criteria=lambda: (
+                        not self._is_at_end() and not self._lookahead() == '"'
+                    ),
+                    terminated_string_criteria=lambda: self._is_at_end(),
+                )
 
             case _ if c in "0123456789":
                 # consumimos el número hasta que no sea un dígito o un punto para decimales
@@ -228,6 +217,12 @@ class Scanner(object):
 
         return self.source[self.current]
 
+    def _lookahead_next(self) -> str:
+        if self.current + 1 >= len(self.source):
+            return "\0"
+
+        return self.source[self.current + 1]
+
     # Consume un caracter y lo devuelve
     def _advance(self) -> str:
         lookahead = self._lookahead()
@@ -247,3 +242,72 @@ class Scanner(object):
 
         self._advance()
         return True
+
+    def _scan_string(
+        self, string_eof_criteria: Callable, terminated_string_criteria: Callable
+    ):
+        """
+        Escanea un string hasta que se deje de cumplir "string_eof_criteria"
+        Una vez que se deje de cumplir, chequea si se cumplió "terminated_string_criteria" para lanzar un error de string sin cerrar,
+        o si no, consume el cierre del string y lo guarda como token.
+        Maneja la interpolación de strings, que tiene la forma `${expresion}`.
+        Si encuentra una interpolacion, se encarga de empaquetar el string para que los tokens queden ordenados
+        de la forma [ INTERPOLATION_START, STRING, ..., INTERPOLATION_END ].
+        Por ejemplo, para el caso "hola ${nombre}!", los tokens serían:
+        [ INTERPOLATION_START, STRING<'hola '>, IDENTIFIER<nombre>, STRING<'!'>, INTERPOLATION_END ]
+        """
+        has_interpolation = False
+
+        while string_eof_criteria():
+            if self._lookahead() == "$" and self._lookahead_next() == "{":
+                # Si no es la primera interpolacion, no agregamos offset al literal
+                # Esto skippeaba el char despues de '}' y algo como
+                # "${var} hola ${var2}" resultaba en [ INTERPOLATION_START, IDENTIFIER<var>, STRING<'hola ', IDENTIFIER<var2>, INTERPOLATION_END ]
+                # Notar la falta de espacio antes de 'hola ' en STRING<'hola '>
+                start_offset = 1 if not has_interpolation else 0
+                str_literal = self.source[self.start + start_offset : self.current]
+                self.add_token(TokenType.STRING, literal=str_literal)
+
+                self.add_token(TokenType.INTERPOLATION_START)
+                has_interpolation = True
+
+                # Salteamos '${'
+                self._advance()
+                self._advance()
+                self.start = self.current
+
+                brace_depth = 1
+                while brace_depth > 0 and not self._is_at_end():
+                    char = self._lookahead()
+
+                    if char == "{":
+                        brace_depth += 1
+                    elif char == "}":
+                        brace_depth -= 1
+
+                    if brace_depth > 0:
+                        # Escaneamos los tokens contenidos dentro de la interpolacion
+                        self.scan_token()
+                        self.start = self.current
+                    else:
+                        self.add_token(TokenType.INTERPOLATION_END)
+                        self._advance()
+                        self.start = self.current
+
+                if brace_depth > 0:
+                    raise Exception(f"Unterminated interpolation: `{self.lexeme()}`")
+
+                continue
+
+            self._advance()
+
+        if terminated_string_criteria():
+            # si llegamos al final del archivo, sin cerrar la cadena, es un error
+            raise Exception(f"Unterminated string: `{self.lexeme()}`")
+
+        self._advance()  # consumimos el cierre de la cadena
+
+        # la cadena la guardamos sin las comillas
+        start_offset = 1 if not has_interpolation else 0
+        strvalue = self.source[self.start + start_offset : self.current - 1]
+        self.add_token(TokenType.STRING, literal=strvalue)

--- a/plox/Scanner.py
+++ b/plox/Scanner.py
@@ -209,19 +209,17 @@ class Scanner(object):
     def _is_at_end(self) -> bool:
         return self.current >= len(self.source)
 
-    # Devuelve el caracter actual, sin consumirlo
-    def _lookahead(self) -> str:
+    def _lookahead(self, offset: int = 0) -> str:
+        """
+        Devuelve el caracter actual, sin consumirlo.
+        Si se pasa un offset, devuelve el caracter que está a esa distancia del actual.
+        """
+
         # si llegamos al final de la linea, no hay nada para mirar
-        if self._is_at_end():
+        if self.current + offset >= len(self.source):
             return "\0"
 
-        return self.source[self.current]
-
-    def _lookahead_next(self) -> str:
-        if self.current + 1 >= len(self.source):
-            return "\0"
-
-        return self.source[self.current + 1]
+        return self.source[self.current + offset]
 
     # Consume un caracter y lo devuelve
     def _advance(self) -> str:
@@ -259,7 +257,7 @@ class Scanner(object):
         has_interpolation = False
 
         while string_eof_criteria():
-            if self._lookahead() == "$" and self._lookahead_next() == "{":
+            if self._lookahead() == "$" and self._lookahead(offset=1) == "{":
                 # Si no es la primera interpolacion, no agregamos offset al literal
                 # Esto skippeaba el char despues de '}' y algo como
                 # "${var} hola ${var2}" resultaba en

--- a/plox/Token.py
+++ b/plox/Token.py
@@ -59,6 +59,9 @@ class TokenType(Enum):
     BREAK = auto()
     CONTINUE = auto()
 
+    INTERPOLATION_START = auto()
+    INTERPOLATION_END = auto()
+
     # type casting tokens
     BOOL_CAST = auto()
     NUMBER_CAST = auto()

--- a/plox/Utils.py
+++ b/plox/Utils.py
@@ -7,7 +7,7 @@ def golden_rule_print(*args, **kwargs):
     print(*transformed_args, **kwargs)  # type: ignore
 
 
-def stringify(value: Any) -> str:
+def stringify(value: Any, skip_quotes=False) -> str:
     """
     Golden rule: Convierte cualquier valor de Python a una representación de cadena que se parezca a cómo se mostraría en Lox.
     """
@@ -24,7 +24,7 @@ def stringify(value: Any) -> str:
             )
             return f"{'[' + items + ']'}"
         case str():
-            return f"'{value}'"
+            return f"'{value}'" if not skip_quotes else value
         case int() | float():
             if isinstance(value, float) and value.is_integer():
                 return str(int(value))

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -783,3 +783,199 @@ def test_golden_rule(capsys):
     out = capsys.readouterr().out
     assert out == "['a': 1, 'b': 2]\n"
     assert out != "{'a': 1, 'b': 2}\n"
+
+
+def test_string_interpolation_simple(capsys):
+    tokens = Scanner('const mundo = "Mundo"; print "hola, ${mundo}!";').scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'hola, Mundo!'\n"
+
+
+def test_string_interpolation_with_ternary(capsys):
+    tokens = Scanner('print "hola, ${true ? "amigo" : "desconocido"}!";').scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'hola, amigo!'\n"
+
+    tokens = Scanner('print "hola, ${false ? "amigo" : "desconocido"}!";').scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'hola, desconocido!'\n"
+
+
+def test_string_interpolation_double(capsys):
+    tokens = Scanner(
+        'const mundo = "Mundo"; const quien = "Plox"; print "hola, ${mundo} por parte de ${quien}!";'
+    ).scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'hola, Mundo por parte de Plox!'\n"
+
+
+def test_string_interpolation_recursive(capsys):
+    tokens = Scanner(
+        'const mundostr = "Mundo"; const quien = "Plox"; print "hola, ${"mundostr ${quien}!"}";'
+    ).scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'hola, mundostr Plox!'\n"
+
+
+def test_string_interpolation_nested_100_deep(capsys):
+    DEPTH = 10
+    interpolation = '"${' * DEPTH + "x" + '}"' * DEPTH + ";"
+    tokens = Scanner("const x = 10; print" + interpolation).scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'10'\n"
+
+
+def test_string_interpolation_negate_bool(capsys):
+    tokens = Scanner('print "hola, ${!true}!";').scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'hola, false!'\n"
+
+
+def test_string_interpolation_with_array_indexing(capsys):
+    tokens = Scanner(
+        'const arr = [1, 2, 3]; print "el segundo elemento es ${arr[1]}";'
+    ).scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'el segundo elemento es 2'\n"
+
+
+def test_string_interpolation_with_dict_indexing(capsys):
+    tokens = Scanner(
+        'const dict = ["key": "value"]; print "el valor de la clave es ${dict["key"]}";'
+    ).scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'el valor de la clave es value'\n"
+
+
+def test_string_interpolation_with_function_call(capsys):
+    tokens = Scanner(
+        'fun greet(name) { return "hola, ${name}!"; } print greet("Plox");'
+    ).scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'hola, Plox!'\n"
+
+
+def test_string_interpolation_with_nested_function_call(capsys):
+    tokens = Scanner(
+        'fun greet(name) { return "hola, ${name}!"; } print "saludo: ${greet("Plox")}";'
+    ).scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'saludo: hola, Plox!'\n"
+
+
+def test_string_interpolation_with_ternary_and_function_call(capsys):
+    tokens = Scanner(
+        'fun greet(name) { return "hola, ${name}!"; } print "saludo: ${true ? greet("Plox") : "desconocido"}";'
+    ).scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'saludo: hola, Plox!'\n"
+
+
+def test_string_interpolation_with_sum(capsys):
+    tokens = Scanner('const a = 5; const b = 10; print "la suma es ${a + b}";').scan()
+    stmts = Parser(tokens).parse()
+    interpreter = Interpreter()
+    resolver = Resolver(interpreter)
+    for stmt in stmts:
+        resolver.resolve(stmt)
+
+    interpreter.interpret(stmts)
+    out = capsys.readouterr().out
+
+    assert out == "'la suma es 15'\n"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,6 +2,7 @@ import pytest
 from plox.Expr import (
     BinaryExpr,
     GroupingExpr,
+    JoinedStringExpr,
     LiteralExpr,
     UnaryExpr,
     AssignmentExpr,
@@ -729,3 +730,160 @@ def test_switch_errors():
     with pytest.raises(SyntaxError) as excinfo:
         Parser(tokens).parse()
     assert "Expected ':'" in str(excinfo.value)
+
+
+def test_string_interpolation_simple():
+    tokens = Scanner('"hola, ${mundo}!";').scan()
+    stmts = Parser(tokens).parse()
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], ExpressionStmt)
+    assert isinstance(stmts[0].expression, JoinedStringExpr)
+    for part in stmts[0].expression.parts:
+        if isinstance(part, LiteralExpr):
+            assert part.value in ["hola, ", "!"]
+        elif isinstance(part, VariableExpr):
+            assert part.name.lexeme == "mundo"
+        else:
+            assert False, f"Unexpected part type: {type(part)}"
+
+
+def test_string_interpolation_with_ternary():
+    tokens = Scanner('"hola, ${condicion ? "amigo" : "desconocido"}!";').scan()
+    stmts = Parser(tokens).parse()
+
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], ExpressionStmt)
+    assert isinstance(stmts[0].expression, JoinedStringExpr)
+    for part in stmts[0].expression.parts:
+        if isinstance(part, LiteralExpr):
+            assert part.value in ["hola, ", "!"]
+        elif isinstance(part, TernaryExpr):
+            assert isinstance(part.condition, VariableExpr)
+            assert part.condition.name.lexeme == "condicion"
+            assert isinstance(part.true_branch, LiteralExpr)
+            assert part.true_branch.value == "amigo"
+            assert isinstance(part.false_branch, LiteralExpr)
+            assert part.false_branch.value == "desconocido"
+        else:
+            assert False, f"Unexpected part type: {type(part)}"
+
+
+def test_string_interpolation_double():
+    tokens = Scanner('"hola, ${mundo} por parte de ${quien}!";').scan()
+    stmts = Parser(tokens).parse()
+
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], ExpressionStmt)
+    assert isinstance(stmts[0].expression, JoinedStringExpr)
+    for part in stmts[0].expression.parts:
+        if isinstance(part, LiteralExpr):
+            assert part.value in ["hola, ", " por parte de ", "!"]
+        elif isinstance(part, VariableExpr):
+            assert part.name.lexeme in ["mundo", "quien"]
+        else:
+            assert False, f"Unexpected part type: {type(part)}"
+
+
+def test_string_interpolation_recursive():
+    tokens = Scanner('"hola, ${"mundo ${quien}!"}";').scan()
+    stmts = Parser(tokens).parse()
+
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], ExpressionStmt)
+    assert isinstance(stmts[0].expression, JoinedStringExpr)
+    for part in stmts[0].expression.parts:
+        if isinstance(part, LiteralExpr):
+            assert part.value in ["hola, ", ""]
+        elif isinstance(part, JoinedStringExpr):
+            inner_parts = part.parts
+            assert len(inner_parts) == 3
+            assert isinstance(inner_parts[0], LiteralExpr)
+            assert inner_parts[0].value == "mundo "
+            assert isinstance(inner_parts[1], VariableExpr)
+            assert inner_parts[1].name.lexeme == "quien"
+            assert isinstance(inner_parts[2], LiteralExpr)
+            assert inner_parts[2].value == "!"
+        else:
+            assert False, f"Unexpected part type: {type(part)}"
+
+
+def test_string_interpolation_nested_100_deep():
+    DEPTH = 10
+    interpolation = '"${' * DEPTH + "x" + '}"' * DEPTH + ";"
+    tokens = Scanner(interpolation).scan()
+    stmts = Parser(tokens).parse()
+
+    assert len(stmts) == 1
+    assert isinstance(stmts[0], ExpressionStmt)
+    assert isinstance(stmts[0].expression, JoinedStringExpr)
+    ref = stmts[0].expression
+    for _ in range(DEPTH - 1):
+        part = ref.parts[1]
+        assert isinstance(part, JoinedStringExpr)
+        ref = part
+    assert isinstance(ref.parts[1], VariableExpr)
+    assert ref.parts[1].name.lexeme == "x"
+
+
+def test_string_interpolation_only_allows_expressions():
+    tokens = Scanner(
+        '"hola, ${fun obtener_nombre() {return "plox";} obtener_nombre()}!";'
+    ).scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `FUN` instead" in str(excinfo.value)
+
+    tokens = Scanner('"hola, ${var x = 5;}!";').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `VAR` instead" in str(excinfo.value)
+
+    tokens = Scanner('"hola, ${if (cond) print 1;}!";').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `IF` instead" in str(excinfo.value)
+
+    tokens = Scanner('"hola, ${for (var i = 0; i < 3; i = i + 1) print i;}!";').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `FOR` instead" in str(excinfo.value)
+
+    tokens = Scanner('"hola, ${switch (x) { case 1: print 1; }}!";').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `SWITCH` instead" in str(excinfo.value)
+
+    tokens = Scanner('"hola, ${return 5;}!";').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `RETURN` instead" in str(excinfo.value)
+
+    tokens = Scanner('"hola, ${break;}!";').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `BREAK` instead" in str(excinfo.value)
+
+    tokens = Scanner('"hola, ${continue;}!";').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `CONTINUE` instead" in str(excinfo.value)
+
+    tokens = Scanner('"hola, ${while (cond) print 1;}!";').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `WHILE` instead" in str(excinfo.value)
+
+    tokens = Scanner('"hola, ${ { print 1; } }!";').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert "Expected expression, got `LEFT_BRACE` instead" in str(excinfo.value)
+
+
+def test_string_interpolation_allow_only_one_expression():
+    tokens = Scanner('"${1 2 3}"').scan()
+    with pytest.raises(Exception) as excinfo:
+        Parser(tokens).parse()
+    assert (
+        "Expected '}' after interpolated expression, got `NUMBER<2.0>` instead"
+        in str(excinfo.value)
+    )

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -421,3 +421,144 @@ def test_switch_not_identifier():
     tokens = Scanner("switching").scan()
     assert tokens[0].token_type == TokenType.IDENTIFIER
     assert tokens[0].lexeme == "switching"
+
+
+def test_string_interpolation_simple():
+    tokens = Scanner('print "hola, ${mundo}!";').scan()
+
+    expected_tokens_type: list[tuple[TokenType, str | None]] = [
+        (TokenType.PRINT, None),
+        (TokenType.STRING, '"hola, '),
+        (TokenType.INTERPOLATION_START, None),
+        (TokenType.IDENTIFIER, "mundo"),
+        (TokenType.INTERPOLATION_END, None),
+        (TokenType.STRING, '!"'),
+        (TokenType.SEMICOLON, None),
+        (TokenType.EOF, None),
+    ]
+
+    for expected, actual in zip(expected_tokens_type, tokens):
+        if expected[1] is not None:
+            assert expected[1] == actual.lexeme
+
+        assert expected[0] == actual.token_type
+
+
+def test_string_interpolation_with_ternary():
+    tokens = Scanner('print "hola, ${condicion ? "amigo" : "desconocido"}!";').scan()
+
+    expected_tokens_type: list[tuple[TokenType, str | None]] = [
+        (TokenType.PRINT, None),
+        (TokenType.STRING, '"hola, '),
+        (TokenType.INTERPOLATION_START, None),
+        (TokenType.IDENTIFIER, "condicion"),
+        (TokenType.QUESTION, None),
+        (TokenType.STRING, '"amigo"'),
+        (TokenType.COLON, None),
+        (TokenType.STRING, '"desconocido"'),
+        (TokenType.INTERPOLATION_END, None),
+        (TokenType.STRING, '!"'),
+        (TokenType.SEMICOLON, None),
+        (TokenType.EOF, None),
+    ]
+
+    for expected, actual in zip(expected_tokens_type, tokens):
+        if expected[1] is not None:
+            assert expected[1] == actual.lexeme
+
+        assert expected[0] == actual.token_type
+
+
+def test_string_interpolation_double():
+    tokens = Scanner('print "hola, ${mundo} por parte de ${quien}!";').scan()
+
+    expected_tokens_type: list[tuple[TokenType, str | None]] = [
+        (TokenType.PRINT, None),
+        (TokenType.STRING, '"hola, '),
+        (TokenType.INTERPOLATION_START, None),
+        (TokenType.IDENTIFIER, "mundo"),
+        (TokenType.INTERPOLATION_END, None),
+        (TokenType.STRING, " por parte de "),
+        (TokenType.INTERPOLATION_START, None),
+        (TokenType.IDENTIFIER, "quien"),
+        (TokenType.INTERPOLATION_END, None),
+        (TokenType.STRING, '!"'),
+        (TokenType.SEMICOLON, None),
+        (TokenType.EOF, None),
+    ]
+
+    for expected, actual in zip(expected_tokens_type, tokens):
+        if expected[1] is not None:
+            assert expected[1] == actual.lexeme
+
+        assert expected[0] == actual.token_type
+
+
+def test_string_interpolation_recursive():
+    tokens = Scanner('print "hola, ${"mundo ${quien}!"}";').scan()
+
+    expected_tokens_type: list[tuple[TokenType, str | None]] = [
+        (TokenType.PRINT, None),
+        (TokenType.STRING, '"hola, '),
+        (TokenType.INTERPOLATION_START, None),
+        (TokenType.STRING, '"mundo '),
+        (TokenType.INTERPOLATION_START, None),
+        (TokenType.IDENTIFIER, "quien"),
+        (TokenType.INTERPOLATION_END, None),
+        (TokenType.STRING, '!"'),
+        (TokenType.INTERPOLATION_END, None),
+        (TokenType.STRING, '"'),
+        (TokenType.SEMICOLON, None),
+        (TokenType.EOF, None),
+    ]
+
+    for expected, actual in zip(expected_tokens_type, tokens):
+        if expected[1] is not None:
+            assert expected[1] == actual.lexeme
+
+        assert expected[0] == actual.token_type
+
+
+def test_string_interpolation_nested_100_deep():
+    DEPTH = 100
+    interpolation = '"${' * DEPTH + "x" + '}"' * DEPTH + ";"
+    tokens = Scanner(interpolation).scan()
+
+    expected_tokens_type = [
+        (TokenType.STRING, '"'),
+        (TokenType.INTERPOLATION_START, None),
+    ] * DEPTH
+    expected_tokens_type += [(TokenType.IDENTIFIER, "x")]
+    expected_tokens_type += [
+        (TokenType.INTERPOLATION_END, None),
+        (TokenType.STRING, '"'),
+    ] * DEPTH
+    expected_tokens_type += [
+        (TokenType.SEMICOLON, None),
+        (TokenType.EOF, None),
+    ]
+
+    for expected, actual in zip(expected_tokens_type, tokens):
+        if expected[1] is not None:
+            assert expected[1] == actual.lexeme
+
+        assert expected[0] == actual.token_type
+
+
+def test_string_interpolation_unterminated():
+    with pytest.raises(Exception) as excinfo:
+        Scanner('print "hola, ${mundo!;').scan()
+    assert "Unterminated interpolation" in str(excinfo.value)
+
+    # Si se inicia un string dentro de la interpolacion y el mismo no se cierra
+    # entonces el error que se lanza es de string sin cerrar,
+    # porque el scanner espera que se cierre el string antes de cerrar la interpolacion
+    with pytest.raises(Exception) as excinfo:
+        Scanner(
+            'print "hola, ${mundo! -->"<-- esto inicia un nuevo string dentro de la interpolacion;'
+        ).scan()
+    assert "Unterminated string" in str(excinfo.value)
+
+    with pytest.raises(Exception) as excinfo:
+        Scanner('print "hola, ${mundo} por parte de ${quien!;').scan()
+    assert "Unterminated interpolation" in str(excinfo.value)


### PR DESCRIPTION
# String interpolation
Este PR resuelve la issue #30 

## Scanner
- Se refactorizo la logica de scaneo de strings. Ahora dependiendo que tipo de string sea `'` o `"` utilizan la funcion `_scan_string` con diferentes `Callable` para determinar cuando considera terminado el fin del mismo.

- Se agregaron los `Tokentype` `INTERPOLATION_START` e `INTERPOLATION_END`, estos mismos son generados dentro del escaneo de un string para permitir interpolar expresiones en el.

## Parser
- Al parsear un `primary expr` se distingue String de Number, ahora, al parsear un `TokenType.STRING` debemos ver si el proximo token es de tipo `INTERPOLATION_START`, en caso afirmativo, comenzamos a armar un JoinStringExpr. Cada interpolacion solo puede tener una unica **expresion** wrappeada, esto es, que no podriamos hacer cosas como `"${1 2 3}"` (3 expr) pero si cosas como `"${true ? "${ false ? "true_inner" : "false_inner"}" : "${ true ? 1 : 2 }" }"` (1 expr)

## Interpreter
- Al evaluar una JoinStringExpr, unimos todas las partes de la misma. Utilizando la utilidad stringify para adaptar los valores interpolados a lox. 

## Utils
- Se agrega el flag `skip_quotes` a `stringify` para evitar situaciones como estas:
```
> const name = "plox";
> print "${name}";
''''plox''''
```
Esto sucedia ya que a una interpolacion siempre la antecede un STRING (aunque este vacio) y le sigue otro STRING (aunque este vacio).

## Test y ejemplos
- Se agregaron ejemplos en examples/string_interpolation.lox
- Se agregaron tests para el Scanner, Parser e Interprete 


## Comparativa con la sintaxis de otros lenguajes
### Javascript

La sintaxis para interpolar strings en javascript es la siguiente
```js
const name = "Plox";
const s = `Hi, ${name}`;
```
Utilizada de una manera similar por Python (con los f-strings), C#, Swift, Bash, entre otros. Podemos ver que es similar a la implementada en este PR para lox, a diferencia de que en nuestro caso no requiere obligatoriamente iniciar un string con backticks ``` ` ```, ya que tanto para strings con `'` y `"` permitimos interpolaciones.
Esto hace que dentro de los strings tengamos keywords (`${` y ``` ` ``` (para el caso de js)) que debemos escapear o tratar de otra forma si es que realmente queremos incluirlas en el mismo.

### Python

Python por su parte cuenta con varias sintaxis para lograr interpolar un string (ademas de los f-strings mencionados)

#### %-format
```python
a, b = 5, 2
print('Sum of %d and %d is %d' % (a, b, a+b))
```
Utilizado por otros lenguajes como C, C++, Java, Golang, etc. Ademas de tener ciertos caracteres reservados (`%`) unicamente permite interpolar los tipos de valores que son soportados (generalmente primitivos (str, float, int, bool)) haciendo que sea necesario castear el valor que queremos interpolar previamente.

#### format
```python
a, b = 5, 2
print('Sum of {} and {} is {}'.format(a, b, a+b))
print('Sum of {num1} and {num2} is {sum}'.format(num1=a, num2=b, sum=a+b))
```
Utilizado por otros lenguajes como Rust, Java, C#, etc. Ademas de tener los caracteres reservados (`{` y `}`), se puede volver tedioso para el programador el tener que estar constantemente saltando entre el string en si y los valores a ser interpolados.

